### PR TITLE
feat(ui): game flow screens — main menu, character select, victory, scene manager

### DIFF
--- a/.squad/agents/wedge/history.md
+++ b/.squad/agents/wedge/history.md
@@ -1,5 +1,32 @@
 # Wedge — History (formerly Hockney)
 
+## Ashfall — Game Flow Screens (Issue #12, PR TBD)
+**Date:** 2025-07-23
+**Branch:** `squad/12-menus`
+**Files:** `scenes/ui/main_menu.tscn`, `scripts/ui/main_menu.gd`, `scenes/ui/character_select.tscn`, `scripts/ui/character_select.gd`, `scenes/ui/victory_screen.tscn`, `scripts/ui/victory_screen.gd`, `scripts/systems/scene_manager.gd`, `project.godot`
+
+Built the complete game flow UI for Ashfall. Key deliverables:
+
+- **Main Menu:** "ASHFALL" title with sine-wave ember glow pulse (warm white ↔ orange outline), 4 buttons (VS CPU, VS Player, Options, Quit) with dark volcanic panel styling + ember-orange borders. Options panel overlays with Master/SFX/Music volume sliders (placeholder — no audio bus wired yet). First Frame Studios credit at bottom. Full keyboard/gamepad navigation via focus neighbors. ESC closes options.
+
+- **Character Select:** Two-panel layout (P1 left, P2 right) with VS in center. Colored rectangles as portrait placeholders (Kael = blue, Rhena = red). P1 navigates with A/D (p1_left/p1_right), confirms with U (p1_light_punch), cancels with L (p1_block). P2 uses arrow keys and numpad. In VS CPU mode, P2 auto-picks the opposite character. Shows character name + archetype ("Balanced" / "Rushdown"). 0.5s delay after both confirm before fade transition. ESC backs out or deconfirms.
+
+- **Victory Screen:** "[NAME] WINS!" in gold with glow pulse. Dynamic stat rows (rounds, total damage, longest combo, ember spent) built from SceneManager.match_stats dictionary. Rematch and Main Menu buttons with focus neighbors.
+
+- **Scene Manager (autoload):** CanvasLayer at layer 100 with ColorRect overlay for fade-to-black transitions (0.4s each direction via Tween). Stores game_mode ("vs_cpu"/"vs_player"), p1/p2 character selections, and match_stats across scene changes. Methods: `goto_main_menu()`, `goto_character_select(mode)`, `goto_fight()`, `goto_victory(winner, stats)`, `rematch()`. Listens to EventBus.scene_change_requested for decoupled scene transitions.
+
+- **project.godot updates:** Set `run/main_scene` to `res://scenes/ui/main_menu.tscn`. Added `SceneManager` to autoload list.
+
+**Learnings:**
+- Scene manager as CanvasLayer autoload at layer 100 keeps fade overlay above all game content including the fight HUD (layer 10).
+- Tween chain (fade in → swap scene → fade out → re-enable input) prevents input during transitions without manual state tracking.
+- Character select uses `wrapi()` for index cycling — cleaner than modulo with boundary checks.
+- VS CPU mode auto-mirrors character selection (picks opposite of P1) — no P2 input handling needed.
+- All buttons use unique_name_in_owner for `%Name` access pattern, matching fight_hud.tscn conventions.
+- Dark volcanic palette (bg: 0.04/0.03/0.06, panels: 0.06-0.12 with ember-orange borders) carries the Ashfall art direction from GDD into menus.
+
+---
+
 ## Project Context
 - **Project:** Ashfall (1v1 fighting game, Godot 4) + firstPunch (browser beat 'em up)
 - **User:** joperezd

--- a/games/ashfall/project.godot
+++ b/games/ashfall/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="Ashfall"
 config/features=PackedStringArray("4.6", "Mobile")
 config/icon="res://icon.svg"
-run/main_scene="res://scenes/main/fight_scene.tscn"
+run/main_scene="res://scenes/ui/main_menu.tscn"
 run/max_fps=60
 
 [autoload]
@@ -21,6 +21,7 @@ run/max_fps=60
 EventBus="*res://scripts/systems/event_bus.gd"
 GameState="*res://scripts/systems/game_state.gd"
 VFXManager="*res://scripts/systems/vfx_manager.gd"
+SceneManager="*res://scripts/systems/scene_manager.gd"
 
 [display]
 

--- a/games/ashfall/scenes/ui/character_select.tscn
+++ b/games/ashfall/scenes/ui/character_select.tscn
@@ -1,0 +1,229 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/character_select.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.08, 0.06, 0.1, 0.92)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.4, 0.3, 0.15, 0.5)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0.04, 0.03, 0.06, 1)
+
+[node name="CharacterSelect" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_script")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.04, 0.03, 0.06, 1)
+
+[node name="Title" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.0
+anchor_top = 0.03
+anchor_right = 1.0
+anchor_bottom = 0.12
+horizontal_alignment = 1
+vertical_alignment = 1
+text = "SELECT YOUR FIGHTER"
+theme_override_colors/font_color = Color(1, 0.85, 0.5, 1)
+theme_override_colors/font_outline_color = Color(0.6, 0.3, 0.0, 0.8)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 36
+
+[node name="ModeLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.0
+anchor_top = 0.1
+anchor_right = 1.0
+anchor_bottom = 0.15
+horizontal_alignment = 1
+vertical_alignment = 1
+text = "VS CPU"
+theme_override_colors/font_color = Color(0.7, 0.65, 0.55, 0.6)
+theme_override_font_sizes/font_size = 16
+
+[node name="Panels" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.05
+anchor_top = 0.17
+anchor_right = 0.95
+anchor_bottom = 0.88
+alignment = 1
+
+[node name="P1Panel" type="PanelContainer" parent="Panels"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 1.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="P1VBox" type="VBoxContainer" parent="Panels/P1Panel"]
+layout_mode = 2
+alignment = 1
+
+[node name="P1Header" type="Label" parent="Panels/P1Panel/P1VBox"]
+layout_mode = 2
+text = "PLAYER 1"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(0.31, 0.765, 0.969, 0.8)
+theme_override_font_sizes/font_size = 18
+
+[node name="Spacer" type="Control" parent="Panels/P1Panel/P1VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 12)
+
+[node name="P1Portrait" type="ColorRect" parent="Panels/P1Panel/P1VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 260)
+size_flags_horizontal = 4
+color = Color(0.31, 0.765, 0.969, 1)
+
+[node name="Spacer2" type="Control" parent="Panels/P1Panel/P1VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 12)
+
+[node name="P1NameLabel" type="Label" parent="Panels/P1Panel/P1VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Kael"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.95, 0.8, 1)
+theme_override_font_sizes/font_size = 28
+
+[node name="P1ArchetypeLabel" type="Label" parent="Panels/P1Panel/P1VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Balanced"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(0.7, 0.65, 0.55, 0.7)
+theme_override_font_sizes/font_size = 16
+
+[node name="Spacer3" type="Control" parent="Panels/P1Panel/P1VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 8)
+
+[node name="P1StatusLabel" type="Label" parent="Panels/P1Panel/P1VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "← A/D →  [U] Confirm"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.7, 0.2, 0.7)
+theme_override_font_sizes/font_size = 14
+
+[node name="VsSpacer" type="Control" parent="Panels"]
+layout_mode = 2
+custom_minimum_size = Vector2(60, 0)
+
+[node name="VsLabel" type="Label" parent="Panels/VsSpacer"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -30.0
+offset_top = -25.0
+offset_right = 30.0
+offset_bottom = 25.0
+horizontal_alignment = 1
+vertical_alignment = 1
+text = "VS"
+theme_override_colors/font_color = Color(1, 0.85, 0.5, 0.6)
+theme_override_colors/font_outline_color = Color(0.6, 0.3, 0.0, 0.5)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 40
+
+[node name="P2Panel" type="PanelContainer" parent="Panels"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 1.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="P2VBox" type="VBoxContainer" parent="Panels/P2Panel"]
+layout_mode = 2
+alignment = 1
+
+[node name="P2Header" type="Label" parent="Panels/P2Panel/P2VBox"]
+layout_mode = 2
+text = "PLAYER 2"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(0.937, 0.325, 0.314, 0.8)
+theme_override_font_sizes/font_size = 18
+
+[node name="Spacer" type="Control" parent="Panels/P2Panel/P2VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 12)
+
+[node name="P2Portrait" type="ColorRect" parent="Panels/P2Panel/P2VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 260)
+size_flags_horizontal = 4
+color = Color(0.937, 0.325, 0.314, 1)
+
+[node name="Spacer2" type="Control" parent="Panels/P2Panel/P2VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 12)
+
+[node name="P2NameLabel" type="Label" parent="Panels/P2Panel/P2VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Rhena"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.95, 0.8, 1)
+theme_override_font_sizes/font_size = 28
+
+[node name="P2ArchetypeLabel" type="Label" parent="Panels/P2Panel/P2VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Rushdown"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(0.7, 0.65, 0.55, 0.7)
+theme_override_font_sizes/font_size = 16
+
+[node name="Spacer3" type="Control" parent="Panels/P2Panel/P2VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 8)
+
+[node name="P2StatusLabel" type="Label" parent="Panels/P2Panel/P2VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "← ←/→ →  [Num4] Confirm"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.7, 0.2, 0.7)
+theme_override_font_sizes/font_size = 14
+
+[node name="HintLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.0
+anchor_top = 0.92
+anchor_right = 1.0
+anchor_bottom = 0.98
+horizontal_alignment = 1
+vertical_alignment = 1
+text = "ESC — Back"
+theme_override_colors/font_color = Color(0.5, 0.45, 0.38, 0.4)
+theme_override_font_sizes/font_size = 13

--- a/games/ashfall/scenes/ui/main_menu.tscn
+++ b/games/ashfall/scenes/ui/main_menu.tscn
@@ -1,0 +1,287 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/main_menu.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0.04, 0.03, 0.06, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_btn"]
+bg_color = Color(0.12, 0.08, 0.08, 0.9)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(1.0, 0.45, 0.08, 0.4)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_btn_hover"]
+bg_color = Color(0.2, 0.1, 0.05, 0.95)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(1.0, 0.6, 0.15, 0.8)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_options_panel"]
+bg_color = Color(0.06, 0.04, 0.08, 0.95)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.5, 0.35, 0.1, 0.5)
+
+[node name="MainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
+script = ExtResource("1_script")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.04, 0.03, 0.06, 1)
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 0.12
+anchor_right = 0.5
+anchor_bottom = 0.85
+offset_left = -200.0
+offset_right = 200.0
+grow_horizontal = 2
+alignment = 1
+
+[node name="TitleLabel" type="Label" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "ASHFALL"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.92, 0.7, 1)
+theme_override_colors/font_outline_color = Color(1.0, 0.45, 0.08, 0.9)
+theme_override_constants/outline_size = 6
+theme_override_font_sizes/font_size = 80
+
+[node name="Spacer1" type="Control" parent="VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 40)
+
+[node name="VsCpuButton" type="Button" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(300, 50)
+focus_mode = 2
+text = "VS  CPU"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_btn_hover")
+
+[node name="Spacer2" type="Control" parent="VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 8)
+
+[node name="VsPlayerButton" type="Button" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(300, 50)
+focus_mode = 2
+text = "VS  PLAYER"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_btn_hover")
+
+[node name="Spacer3" type="Control" parent="VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 8)
+
+[node name="OptionsButton" type="Button" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(300, 50)
+focus_mode = 2
+text = "OPTIONS"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_btn_hover")
+
+[node name="Spacer4" type="Control" parent="VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 8)
+
+[node name="QuitButton" type="Button" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(300, 50)
+focus_mode = 2
+text = "QUIT"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_btn_hover")
+
+[node name="CreditLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -40.0
+horizontal_alignment = 1
+vertical_alignment = 2
+text = "First Frame Studios"
+theme_override_colors/font_color = Color(0.55, 0.5, 0.42, 0.5)
+theme_override_font_sizes/font_size = 14
+
+[node name="OptionsPanel" type="PanelContainer" parent="."]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.25
+anchor_top = 0.2
+anchor_right = 0.75
+anchor_bottom = 0.8
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_options_panel")
+
+[node name="OptionsVBox" type="VBoxContainer" parent="OptionsPanel"]
+layout_mode = 2
+alignment = 1
+
+[node name="OptionsTitle" type="Label" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+text = "OPTIONS"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.85, 0.5, 1)
+theme_override_font_sizes/font_size = 32
+
+[node name="Spacer" type="Control" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 24)
+
+[node name="MasterRow" type="HBoxContainer" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+alignment = 1
+
+[node name="MasterLabel" type="Label" parent="OptionsPanel/OptionsVBox/MasterRow"]
+layout_mode = 2
+custom_minimum_size = Vector2(180, 0)
+text = "Master Volume"
+horizontal_alignment = 2
+theme_override_colors/font_color = Color(0.85, 0.8, 0.7, 1)
+theme_override_font_sizes/font_size = 18
+
+[node name="MasterSlider" type="HSlider" parent="OptionsPanel/OptionsVBox/MasterRow"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 0)
+min_value = 0.0
+max_value = 100.0
+value = 80.0
+
+[node name="Spacer2" type="Control" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 12)
+
+[node name="SfxRow" type="HBoxContainer" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+alignment = 1
+
+[node name="SfxLabel" type="Label" parent="OptionsPanel/OptionsVBox/SfxRow"]
+layout_mode = 2
+custom_minimum_size = Vector2(180, 0)
+text = "SFX Volume"
+horizontal_alignment = 2
+theme_override_colors/font_color = Color(0.85, 0.8, 0.7, 1)
+theme_override_font_sizes/font_size = 18
+
+[node name="SfxSlider" type="HSlider" parent="OptionsPanel/OptionsVBox/SfxRow"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 0)
+min_value = 0.0
+max_value = 100.0
+value = 80.0
+
+[node name="Spacer3" type="Control" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 12)
+
+[node name="MusicRow" type="HBoxContainer" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+alignment = 1
+
+[node name="MusicLabel" type="Label" parent="OptionsPanel/OptionsVBox/MusicRow"]
+layout_mode = 2
+custom_minimum_size = Vector2(180, 0)
+text = "Music Volume"
+horizontal_alignment = 2
+theme_override_colors/font_color = Color(0.85, 0.8, 0.7, 1)
+theme_override_font_sizes/font_size = 18
+
+[node name="MusicSlider" type="HSlider" parent="OptionsPanel/OptionsVBox/MusicRow"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 0)
+min_value = 0.0
+max_value = 100.0
+value = 80.0
+
+[node name="Spacer4" type="Control" parent="OptionsPanel/OptionsVBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 24)
+
+[node name="OptionsBackButton" type="Button" parent="OptionsPanel/OptionsVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 44)
+size_flags_horizontal = 4
+focus_mode = 2
+text = "BACK"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_btn_hover")

--- a/games/ashfall/scenes/ui/victory_screen.tscn
+++ b/games/ashfall/scenes/ui/victory_screen.tscn
@@ -1,0 +1,116 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/victory_screen.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.06, 0.04, 0.08, 0.95)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(1.0, 0.7, 0.15, 0.4)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_btn"]
+bg_color = Color(0.12, 0.08, 0.08, 0.9)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(1.0, 0.45, 0.08, 0.4)
+
+[node name="VictoryScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_script")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.04, 0.03, 0.06, 1)
+
+[node name="CenterPanel" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.15
+anchor_top = 0.1
+anchor_right = 0.85
+anchor_bottom = 0.9
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="VBox" type="VBoxContainer" parent="CenterPanel"]
+layout_mode = 2
+alignment = 1
+
+[node name="WinnerLabel" type="Label" parent="CenterPanel/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "KAEL WINS!"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.85, 0.3, 1)
+theme_override_colors/font_outline_color = Color(0.7, 0.35, 0.0, 0.9)
+theme_override_constants/outline_size = 4
+theme_override_font_sizes/font_size = 56
+
+[node name="Spacer1" type="Control" parent="CenterPanel/VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 32)
+
+[node name="StatsContainer" type="VBoxContainer" parent="CenterPanel/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Spacer2" type="Control" parent="CenterPanel/VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 40)
+
+[node name="ButtonRow" type="HBoxContainer" parent="CenterPanel/VBox"]
+layout_mode = 2
+alignment = 1
+
+[node name="RematchButton" type="Button" parent="CenterPanel/VBox/ButtonRow"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 50)
+focus_mode = 2
+text = "REMATCH"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 22
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn")
+
+[node name="ButtonSpacer" type="Control" parent="CenterPanel/VBox/ButtonRow"]
+layout_mode = 2
+custom_minimum_size = Vector2(40, 0)
+
+[node name="MenuButton" type="Button" parent="CenterPanel/VBox/ButtonRow"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 50)
+focus_mode = 2
+text = "MAIN MENU"
+theme_override_colors/font_color = Color(0.95, 0.9, 0.8, 1)
+theme_override_colors/font_hover_color = Color(1, 0.7, 0.2, 1)
+theme_override_colors/font_focus_color = Color(1, 0.7, 0.2, 1)
+theme_override_font_sizes/font_size = 22
+theme_override_styles/normal = SubResource("StyleBoxFlat_btn")
+theme_override_styles/hover = SubResource("StyleBoxFlat_btn")
+theme_override_styles/focus = SubResource("StyleBoxFlat_btn")

--- a/games/ashfall/scripts/systems/scene_manager.gd
+++ b/games/ashfall/scripts/systems/scene_manager.gd
@@ -1,0 +1,82 @@
+## Autoload scene manager — handles scene flow and fade transitions.
+## Flow: Main Menu → Character Select → Fight → Victory → (Rematch / Menu)
+extends CanvasLayer
+
+# Fade overlay drawn on top of everything
+var _fade_rect: ColorRect
+var _tween: Tween
+
+const FADE_DURATION: float = 0.4
+
+# Match context carried across scene changes
+var game_mode: String = "vs_cpu"  # "vs_cpu" or "vs_player"
+var p1_character: String = "Kael"
+var p2_character: String = "Rhena"
+var match_stats: Dictionary = {}
+
+# Scene paths
+const SCENE_MAIN_MENU := "res://scenes/ui/main_menu.tscn"
+const SCENE_CHARACTER_SELECT := "res://scenes/ui/character_select.tscn"
+const SCENE_FIGHT := "res://scenes/main/fight_scene.tscn"
+const SCENE_VICTORY := "res://scenes/ui/victory_screen.tscn"
+
+
+func _ready() -> void:
+	layer = 100
+	_create_fade_overlay()
+	EventBus.scene_change_requested.connect(_on_scene_change_requested)
+
+
+func _create_fade_overlay() -> void:
+	_fade_rect = ColorRect.new()
+	_fade_rect.color = Color.BLACK
+	_fade_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_fade_rect.anchors_preset = Control.PRESET_FULL_RECT
+	_fade_rect.modulate.a = 0.0
+	add_child(_fade_rect)
+
+
+func goto_scene(path: String) -> void:
+	_fade_rect.mouse_filter = Control.MOUSE_FILTER_STOP
+	if _tween and _tween.is_running():
+		_tween.kill()
+	_tween = create_tween()
+	_tween.tween_property(_fade_rect, "modulate:a", 1.0, FADE_DURATION)
+	_tween.tween_callback(_swap_scene.bind(path))
+	_tween.tween_property(_fade_rect, "modulate:a", 0.0, FADE_DURATION)
+	_tween.tween_callback(func(): _fade_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE)
+
+
+func _swap_scene(path: String) -> void:
+	get_tree().change_scene_to_file(path)
+
+
+func goto_main_menu() -> void:
+	GameState.current_phase = GameState.GamePhase.TITLE
+	goto_scene(SCENE_MAIN_MENU)
+
+
+func goto_character_select(mode: String) -> void:
+	game_mode = mode
+	GameState.current_phase = GameState.GamePhase.CHARACTER_SELECT
+	goto_scene(SCENE_CHARACTER_SELECT)
+
+
+func goto_fight() -> void:
+	GameState.reset_match()
+	goto_scene(SCENE_FIGHT)
+
+
+func goto_victory(winner_name: String, stats: Dictionary) -> void:
+	match_stats = stats
+	match_stats["winner"] = winner_name
+	GameState.current_phase = GameState.GamePhase.MATCH_END
+	goto_scene(SCENE_VICTORY)
+
+
+func rematch() -> void:
+	goto_fight()
+
+
+func _on_scene_change_requested(scene_path: String) -> void:
+	goto_scene(scene_path)

--- a/games/ashfall/scripts/ui/character_select.gd
+++ b/games/ashfall/scripts/ui/character_select.gd
@@ -1,0 +1,118 @@
+## Character select — two-panel selection with WASD (P1) and Arrows (P2).
+## Confirm with attack, back with block. Transitions to fight when both confirm.
+extends Control
+
+const CHARACTERS := [
+	{"name": "Kael", "archetype": "Balanced", "color": Color(0.31, 0.765, 0.969)},
+	{"name": "Rhena", "archetype": "Rushdown", "color": Color(0.937, 0.325, 0.314)},
+]
+
+# Selection state
+var p1_index: int = 0
+var p2_index: int = 1
+var p1_confirmed: bool = false
+var p2_confirmed: bool = false
+var _transitioning: bool = false
+
+# Node refs
+@onready var p1_portrait: ColorRect = %P1Portrait
+@onready var p1_name_label: Label = %P1NameLabel
+@onready var p1_archetype_label: Label = %P1ArchetypeLabel
+@onready var p1_status_label: Label = %P1StatusLabel
+@onready var p2_portrait: ColorRect = %P2Portrait
+@onready var p2_name_label: Label = %P2NameLabel
+@onready var p2_archetype_label: Label = %P2ArchetypeLabel
+@onready var p2_status_label: Label = %P2StatusLabel
+@onready var vs_label: Label = %VsLabel
+@onready var mode_label: Label = %ModeLabel
+
+
+func _ready() -> void:
+	_update_display()
+	var mode_text := "VS CPU" if SceneManager.game_mode == "vs_cpu" else "VS PLAYER"
+	mode_label.text = mode_text
+
+
+func _process(_delta: float) -> void:
+	if _transitioning:
+		return
+	_handle_p1_input()
+	_handle_p2_input()
+	_check_ready()
+
+
+func _handle_p1_input() -> void:
+	if p1_confirmed:
+		if Input.is_action_just_pressed("p1_block"):
+			p1_confirmed = false
+			_update_display()
+		return
+	if Input.is_action_just_pressed("p1_left"):
+		p1_index = wrapi(p1_index - 1, 0, CHARACTERS.size())
+		_update_display()
+	elif Input.is_action_just_pressed("p1_right"):
+		p1_index = wrapi(p1_index + 1, 0, CHARACTERS.size())
+		_update_display()
+	if Input.is_action_just_pressed("p1_light_punch"):
+		p1_confirmed = true
+		_update_display()
+
+
+func _handle_p2_input() -> void:
+	if SceneManager.game_mode == "vs_cpu":
+		# CPU auto-picks opponent character
+		p2_index = 1 if p1_index == 0 else 0
+		p2_confirmed = p1_confirmed
+		_update_display()
+		return
+	if p2_confirmed:
+		if Input.is_action_just_pressed("p2_block"):
+			p2_confirmed = false
+			_update_display()
+		return
+	if Input.is_action_just_pressed("p2_left"):
+		p2_index = wrapi(p2_index - 1, 0, CHARACTERS.size())
+		_update_display()
+	elif Input.is_action_just_pressed("p2_right"):
+		p2_index = wrapi(p2_index + 1, 0, CHARACTERS.size())
+		_update_display()
+	if Input.is_action_just_pressed("p2_light_punch"):
+		p2_confirmed = true
+		_update_display()
+
+
+func _check_ready() -> void:
+	if p1_confirmed and p2_confirmed and not _transitioning:
+		_transitioning = true
+		SceneManager.p1_character = CHARACTERS[p1_index].name
+		SceneManager.p2_character = CHARACTERS[p2_index].name
+		# Brief delay before transition
+		get_tree().create_timer(0.5).timeout.connect(SceneManager.goto_fight)
+
+
+func _update_display() -> void:
+	var p1 := CHARACTERS[p1_index]
+	var p2 := CHARACTERS[p2_index]
+	p1_portrait.color = p1.color
+	p1_name_label.text = p1.name
+	p1_archetype_label.text = p1.archetype
+	p1_status_label.text = "READY!" if p1_confirmed else "← A/D →  [U] Confirm"
+
+	p2_portrait.color = p2.color
+	p2_name_label.text = p2.name
+	p2_archetype_label.text = p2.archetype
+	if SceneManager.game_mode == "vs_cpu":
+		p2_status_label.text = "CPU" if p2_confirmed else "CPU"
+	else:
+		p2_status_label.text = "READY!" if p2_confirmed else "← ←/→ →  [Num4] Confirm"
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	# Global back — go to main menu
+	if event.is_action_pressed("ui_cancel") and not _transitioning:
+		if p1_confirmed:
+			p1_confirmed = false
+			_update_display()
+		else:
+			SceneManager.goto_main_menu()
+		get_viewport().set_input_as_handled()

--- a/games/ashfall/scripts/ui/main_menu.gd
+++ b/games/ashfall/scripts/ui/main_menu.gd
@@ -1,0 +1,87 @@
+## Main menu — title screen with ember glow, mode selection, and options.
+extends Control
+
+@onready var title_label: Label = %TitleLabel
+@onready var vs_cpu_btn: Button = %VsCpuButton
+@onready var vs_player_btn: Button = %VsPlayerButton
+@onready var options_btn: Button = %OptionsButton
+@onready var quit_btn: Button = %QuitButton
+@onready var options_panel: PanelContainer = %OptionsPanel
+@onready var master_slider: HSlider = %MasterSlider
+@onready var sfx_slider: HSlider = %SfxSlider
+@onready var music_slider: HSlider = %MusicSlider
+@onready var options_back_btn: Button = %OptionsBackButton
+
+var _ember_time: float = 0.0
+var _options_open: bool = false
+
+const CLR_EMBER := Color(1.0, 0.45, 0.08)
+const CLR_EMBER_GLOW := Color(1.0, 0.7, 0.2)
+const CLR_TITLE := Color(1.0, 0.92, 0.7)
+
+
+func _ready() -> void:
+	options_panel.visible = false
+	_wire_buttons()
+	_apply_title_glow()
+	# Focus first button
+	vs_cpu_btn.grab_focus()
+
+
+func _process(delta: float) -> void:
+	_ember_time += delta
+	_apply_title_glow()
+
+
+func _apply_title_glow() -> void:
+	var pulse := (sin(_ember_time * 3.0) + 1.0) * 0.5
+	var glow_color := CLR_TITLE.lerp(CLR_EMBER_GLOW, pulse * 0.4)
+	title_label.add_theme_color_override("font_color", glow_color)
+	title_label.add_theme_color_override("font_outline_color",
+		CLR_EMBER.lerp(CLR_EMBER_GLOW, pulse))
+
+
+func _wire_buttons() -> void:
+	vs_cpu_btn.pressed.connect(_on_vs_cpu)
+	vs_player_btn.pressed.connect(_on_vs_player)
+	options_btn.pressed.connect(_on_options)
+	quit_btn.pressed.connect(_on_quit)
+	options_back_btn.pressed.connect(_on_options_back)
+	# Focus neighbours for keyboard nav
+	vs_cpu_btn.focus_neighbor_bottom = vs_cpu_btn.get_path_to(vs_player_btn)
+	vs_player_btn.focus_neighbor_top = vs_player_btn.get_path_to(vs_cpu_btn)
+	vs_player_btn.focus_neighbor_bottom = vs_player_btn.get_path_to(options_btn)
+	options_btn.focus_neighbor_top = options_btn.get_path_to(vs_player_btn)
+	options_btn.focus_neighbor_bottom = options_btn.get_path_to(quit_btn)
+	quit_btn.focus_neighbor_top = quit_btn.get_path_to(options_btn)
+
+
+func _on_vs_cpu() -> void:
+	SceneManager.goto_character_select("vs_cpu")
+
+
+func _on_vs_player() -> void:
+	SceneManager.goto_character_select("vs_player")
+
+
+func _on_options() -> void:
+	_options_open = true
+	options_panel.visible = true
+	options_back_btn.grab_focus()
+
+
+func _on_options_back() -> void:
+	_options_open = false
+	options_panel.visible = false
+	vs_cpu_btn.grab_focus()
+
+
+func _on_quit() -> void:
+	get_tree().quit()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		if _options_open:
+			_on_options_back()
+			get_viewport().set_input_as_handled()

--- a/games/ashfall/scripts/ui/victory_screen.gd
+++ b/games/ashfall/scripts/ui/victory_screen.gd
@@ -1,0 +1,93 @@
+## Victory screen — displays winner, match stats, and rematch/menu options.
+extends Control
+
+@onready var winner_label: Label = %WinnerLabel
+@onready var stats_container: VBoxContainer = %StatsContainer
+@onready var rematch_btn: Button = %RematchButton
+@onready var menu_btn: Button = %MenuButton
+
+const CLR_GOLD := Color(1.0, 0.85, 0.3)
+const CLR_STAT := Color(0.85, 0.82, 0.75)
+var _glow_time: float = 0.0
+
+
+func _ready() -> void:
+	_populate()
+	_wire_buttons()
+	rematch_btn.grab_focus()
+
+
+func _process(delta: float) -> void:
+	_glow_time += delta
+	var pulse := (sin(_glow_time * 2.5) + 1.0) * 0.5
+	winner_label.add_theme_color_override("font_color",
+		CLR_GOLD.lerp(Color.WHITE, pulse * 0.3))
+
+
+func _populate() -> void:
+	var stats := SceneManager.match_stats
+	var winner_name: String = stats.get("winner", "???")
+	winner_label.text = winner_name.to_upper() + " WINS!"
+
+	# Clear existing stat labels
+	for child in stats_container.get_children():
+		child.queue_free()
+
+	# Build stat lines
+	var p1_score: int = GameState.scores[0]
+	var p2_score: int = GameState.scores[1]
+	_add_stat("Rounds", "%s %d - %d %s" % [
+		SceneManager.p1_character, p1_score, p2_score, SceneManager.p2_character])
+
+	var total_damage: int = stats.get("total_damage", 0)
+	if total_damage > 0:
+		_add_stat("Total Damage", str(total_damage))
+
+	var longest_combo: int = stats.get("longest_combo", 0)
+	if longest_combo > 0:
+		_add_stat("Longest Combo", "%d hits" % longest_combo)
+
+	var ember_spent: int = stats.get("ember_spent", 0)
+	if ember_spent > 0:
+		_add_stat("Ember Spent", str(ember_spent))
+
+
+func _add_stat(stat_name: String, value: String) -> void:
+	var row := HBoxContainer.new()
+	row.alignment = BoxContainer.ALIGNMENT_CENTER
+
+	var name_lbl := Label.new()
+	name_lbl.text = stat_name + ":"
+	name_lbl.add_theme_color_override("font_color", CLR_STAT.darkened(0.2))
+	name_lbl.add_theme_font_size_override("font_size", 20)
+	name_lbl.custom_minimum_size = Vector2(220, 0)
+	name_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+
+	var spacer := Control.new()
+	spacer.custom_minimum_size = Vector2(16, 0)
+
+	var val_lbl := Label.new()
+	val_lbl.text = value
+	val_lbl.add_theme_color_override("font_color", CLR_STAT)
+	val_lbl.add_theme_font_size_override("font_size", 20)
+	val_lbl.custom_minimum_size = Vector2(220, 0)
+
+	row.add_child(name_lbl)
+	row.add_child(spacer)
+	row.add_child(val_lbl)
+	stats_container.add_child(row)
+
+
+func _wire_buttons() -> void:
+	rematch_btn.pressed.connect(_on_rematch)
+	menu_btn.pressed.connect(_on_menu)
+	rematch_btn.focus_neighbor_bottom = rematch_btn.get_path_to(menu_btn)
+	menu_btn.focus_neighbor_top = menu_btn.get_path_to(rematch_btn)
+
+
+func _on_rematch() -> void:
+	SceneManager.rematch()
+
+
+func _on_menu() -> void:
+	SceneManager.goto_main_menu()


### PR DESCRIPTION
Closes #12

## What
Complete game flow UI for Ashfall: Main Menu → Character Select → Fight → Victory → (Rematch / Menu).

## Added
- **Main Menu** (scenes/ui/main_menu.tscn) — ASHFALL title with ember glow, VS CPU / VS Player / Options / Quit buttons, volume slider options panel, First Frame Studios credit
- **Character Select** (scenes/ui/character_select.tscn) — Two-panel P1/P2 layout, colored portrait placeholders (Kael blue, Rhena red), WASD/Arrow nav, LP confirm / Block back, archetype labels
- **Victory Screen** (scenes/ui/victory_screen.tscn) — Winner text with gold pulse, dynamic stat rows, Rematch and Main Menu buttons
- **Scene Manager** (scripts/systems/scene_manager.gd) — Autoload CanvasLayer with fade-to-black transitions, stores game mode + character picks + match stats across scenes
- **project.godot** — Main scene set to main_menu.tscn, SceneManager added to autoload

## Controls
- Character Select P1: A/D to browse, U to confirm, L to cancel
- Character Select P2: ←/→ to browse, Numpad4 to confirm, Numpad3 to cancel
- VS CPU mode auto-selects P2 opponent