### PR TITLE
Pre-M3 Cleanup: Fix #48 #65 #66 #49

### DIFF
--- a/.squad/decisions/inbox/copilot-directive-2026-03-09T09-15-31.md
+++ b/.squad/decisions/inbox/copilot-directive-2026-03-09T09-15-31.md
@@ -1,0 +1,20 @@
+### 2026-03-09T09-15-31: User directives — backlog automation, team autonomy, role overload
+
+**By:** Joaquin (via Copilot)
+
+**Directive 1 — Backlog sync must be automated (CI/CD):**
+The backlog audit should not be manual. Create a CI/CD workflow that scans code for TODOs/FIXMEs and docs for undocumented work items, then auto-creates GitHub issues. This should run naturally as part of the development cycle.
+
+**Directive 2 — Lead autonomy on team bandwidth:**
+The Lead (Jango) should have full authority to read team bottlenecks and adjust workload distribution without needing CEO approval. The bandwidth restriction that limited Jango to 20% tooling was a mistake — the Lead must be empowered to make these calls independently.
+
+**Directive 3 — Automate Mace's wiki/devblog updates:**
+Jango proposed a script to automate wiki and devblog updates (currently Mace's manual responsibility). Joaquin wants this implemented.
+
+**Directive 4 — Solo is overloaded, needs role split:**
+Solo's feedback revealed he's doing architecture review + tracking blockers + rebasing + stale issue management. Architecture review is deep work that can't be done well alongside ops tasks. Consider splitting Solo's role or adding a dedicated integration/ops agent.
+
+**Directive 5 — ADRs and Godot integration testing:**
+Solo proposed ADRs (Architecture Decision Records) and a dedicated integration agent that runs actual Godot game sessions for validation. Both should be evaluated and implemented.
+
+**Why:** User request — captured for team memory

--- a/games/ashfall/scripts/fighters/states/attack_state.gd
+++ b/games/ashfall/scripts/fighters/states/attack_state.gd
@@ -44,8 +44,9 @@ func physics_update() -> void:
 		return
 
 	# Gravity still applies (especially for air attacks)
+	# Frame-based integer math: gravity is per-second, divide by 60 with int()
 	if not fighter.is_on_floor():
-		fighter.velocity.y += fighter.gravity / 60.0
+		fighter.velocity.y += int(fighter.gravity) / 60
 	else:
 		fighter.velocity.y = 0
 

--- a/games/ashfall/scripts/systems/audio_manager.gd
+++ b/games/ashfall/scripts/systems/audio_manager.gd
@@ -41,6 +41,7 @@ var _timer_ticking: bool = false
 
 
 func _ready() -> void:
+	assert(EventBus != null, "AudioManager requires EventBus to load first")
 	_setup_buses()
 	_generate_all_sounds()
 	_create_players()

--- a/games/ashfall/scripts/systems/round_manager.gd
+++ b/games/ashfall/scripts/systems/round_manager.gd
@@ -6,6 +6,12 @@
 ## All timing is frame-based (deterministic at 60 FPS).
 extends Node
 
+
+func _ready() -> void:
+	assert(EventBus != null, "RoundManager requires EventBus to load first")
+	assert(GameState != null, "RoundManager requires GameState to load first")
+
+
 # --- Signals (wired to UI and other systems via fight_scene.gd) ---
 signal round_started(round_number: int)
 signal round_ended(winner: CharacterBody2D, round_number: int)

--- a/games/ashfall/scripts/systems/scene_manager.gd
+++ b/games/ashfall/scripts/systems/scene_manager.gd
@@ -22,6 +22,8 @@ const SCENE_VICTORY := "res://scenes/ui/victory_screen.tscn"
 
 
 func _ready() -> void:
+	assert(EventBus != null, "SceneManager requires EventBus to load first")
+	assert(GameState != null, "SceneManager requires GameState to load first")
 	layer = 100
 	_create_fade_overlay()
 	EventBus.scene_change_requested.connect(_on_scene_change_requested)

--- a/games/ashfall/scripts/systems/vfx_manager.gd
+++ b/games/ashfall/scripts/systems/vfx_manager.gd
@@ -23,6 +23,8 @@ var _ember_emitters: Dictionary = {}  # player_id -> GPUParticles2D
 
 
 func _ready() -> void:
+	assert(EventBus != null, "VFXManager requires EventBus to load first")
+	assert(GameState != null, "VFXManager requires GameState to load first")
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	_wire_signals()
 


### PR DESCRIPTION
## Pre-M3 Cleanup

### Issue #65: Float division in attack_state.gd
Replaced \ighter.gravity / 60.0\ (float division) with \int(fighter.gravity) / 60\ (integer division) to comply with the frame-based deterministic timing convention.

### Issue #66: Autoload order runtime assertions
Added \_ready()\ assertions to RoundManager, VFXManager, AudioManager, and SceneManager verifying their autoload dependencies exist before signal wiring.

### Issue #48: Integration gate passes
Ran \python tools/integration-gate.py\ — all critical validators pass (3/4 PASS, signal wiring warnings are non-fatal). Gate exits with code 0.

### Issue #49: Integration gate already automated
The workflow \.github/workflows/integration-gate.yml\ already triggers on \push: branches: [main]\ and runs the gate post-merge. No changes needed.

### Validation
- Godot 4.6.1 headless: exits cleanly, no errors
- Integration gate: PASS

Closes #65
Closes #66
Closes #48
Closes #49