### PR TITLE
feat: wire combo system — EventBus signal + fight_scene integration

### DIFF
--- a/games/ashfall/scripts/fight_scene.gd
+++ b/games/ashfall/scripts/fight_scene.gd
@@ -6,6 +6,8 @@ extends Node2D
 @onready var fighter2: Fighter = $Fighters/Fighter2
 @onready var camera: CameraController = $Camera2D
 
+var combo_tracker: Node
+
 func _ready() -> void:
 	# Cross-reference opponents
 	fighter1.opponent = fighter2
@@ -32,6 +34,9 @@ func _ready() -> void:
 	# Wire hit_landed signal for damage application
 	EventBus.hit_landed.connect(_on_hit_landed)
 
+	# Combo tracker — counts consecutive hits per fighter
+	_setup_combo_tracker()
+
 	# Start the round system
 	RoundManager.start_match(fighter1, fighter2)
 
@@ -47,3 +52,12 @@ func _on_hit_landed(attacker, target, move: Dictionary) -> void:
 	var damage: int = move.get("damage", 10)
 	if target.has_method("take_damage"):
 		target.take_damage(damage)
+
+func _setup_combo_tracker() -> void:
+	var script := load("res://scripts/systems/combo_tracker.gd")
+	combo_tracker = Node.new()
+	combo_tracker.set_script(script)
+	combo_tracker.name = "ComboTracker"
+	add_child(combo_tracker)
+	combo_tracker.register_fighter(fighter1)
+	combo_tracker.register_fighter(fighter2)

--- a/games/ashfall/scripts/systems/event_bus.gd
+++ b/games/ashfall/scripts/systems/event_bus.gd
@@ -7,6 +7,7 @@ extends Node
 signal hit_landed(attacker, target, move)
 signal hit_blocked(attacker, target, move)
 signal hit_confirmed(attacker, target, move, combo_count: int)
+signal combo_updated(fighter, combo_count: int)
 signal combo_ended(fighter, total_hits: int, total_damage: int)
 
 # --- Fighter signals ---


### PR DESCRIPTION
## Summary

Wire the combo tracking system into the game by adding the missing combo_updated signal to EventBus and integrating combo_tracker.gd into ight_scene.gd.

### Changes

- **EventBus** (vent_bus.gd): Added combo_updated(fighter, combo_count: int) signal for HUD and other systems to listen for combo count changes
- **Fight Scene** (ight_scene.gd): Wire combo tracker as a child node, register both fighters on scene ready

### How it works

The combo tracker (already committed on main) listens to EventBus.hit_landed and:
1. Increments the attacker's combo count on each consecutive hit
2. Emits combo_updated and hit_confirmed through EventBus
3. Resets combo when: opponent recovers (idle/walk/crouch/jump), 60-frame timeout, or hit is blocked
4. Emits combo_ended with total hits and damage when a combo drops

### Validation

- Godot 4.6.1 headless: **PASS** (exit code 0, no errors)
- Signal wiring verified: combo_tracker emits → EventBus declares → consumers can connect

Closes #68