### PR TITLE
feat: camera follow with zoom system

### DIFF
--- a/games/ashfall/scenes/main/fight_scene.tscn
+++ b/games/ashfall/scenes/main/fight_scene.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=8 format=3]
+[gd_scene load_steps=9 format=3]
 
 [ext_resource type="Script" path="res://scripts/fight_scene.gd" id="1_scene"]
 [ext_resource type="PackedScene" path="res://scenes/fighters/fighter_base.tscn" id="2_fighter"]
 [ext_resource type="Resource" path="res://resources/movesets/kael_moveset.tres" id="3_kael"]
 [ext_resource type="Resource" path="res://resources/movesets/rhena_moveset.tres" id="4_rhena"]
+
+[ext_resource type="Script" path="res://scripts/systems/camera_controller.gd" id="5_camera"]
 
 [sub_resource type="WorldBoundaryShape2D" id="SubResource_floor"]
 
@@ -79,3 +81,7 @@ moveset = ExtResource("4_rhena")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(320, 180)
+script = ExtResource("5_camera")
+stage_left = -300.0
+stage_right = 940.0
+camera_y = 180.0

--- a/games/ashfall/scripts/systems/camera_controller.gd
+++ b/games/ashfall/scripts/systems/camera_controller.gd
@@ -1,0 +1,74 @@
+## Camera controller for the fight scene. Follows both fighters with smooth
+## interpolation, zooms based on distance, and clamps to stage boundaries.
+class_name CameraController
+extends Camera2D
+
+## References to both fighters — set by FightScene on _ready().
+var fighter1: Node2D
+var fighter2: Node2D
+
+## Stage boundary X coordinates (inner edges of walls).
+@export var stage_left: float = -300.0
+@export var stage_right: float = 940.0
+
+## Fixed vertical center for the camera.
+@export var camera_y: float = 180.0
+
+## Zoom limits: higher value = tighter (closer), lower = wider.
+@export var zoom_min: Vector2 = Vector2(0.75, 0.75)  # widest — fighters far apart
+@export var zoom_max: Vector2 = Vector2(1.3, 1.3)    # tightest — fighters close
+
+## Distance thresholds that map to zoom range.
+@export var distance_close: float = 150.0
+@export var distance_far: float = 700.0
+
+## Lerp weight per physics frame — lower = smoother.
+@export var position_smoothing: float = 0.08
+@export var zoom_smoothing: float = 0.06
+
+## Viewport size for boundary clamping.
+var _viewport_size: Vector2
+
+
+func _ready() -> void:
+_viewport_size = get_viewport_rect().size
+
+
+func _physics_process(_delta: float) -> void:
+if not fighter1 or not fighter2:
+return
+
+var target_pos := _calculate_target_position()
+var target_zoom := _calculate_target_zoom()
+
+# Clamp position so the camera never shows past stage edges.
+target_pos.x = _clamp_to_stage(target_pos.x, target_zoom.x)
+
+# Smooth interpolation.
+global_position = global_position.lerp(target_pos, position_smoothing)
+zoom = zoom.lerp(target_zoom, zoom_smoothing)
+
+
+func _calculate_target_position() -> Vector2:
+var midpoint_x := (fighter1.global_position.x + fighter2.global_position.x) / 2.0
+return Vector2(midpoint_x, camera_y)
+
+
+func _calculate_target_zoom() -> Vector2:
+var distance := absf(fighter1.global_position.x - fighter2.global_position.x)
+# Normalize distance into 0..1 range between close and far thresholds.
+var t := clampf(
+(distance - distance_close) / (distance_far - distance_close), 0.0, 1.0
+)
+# t=0 (close) → zoom_max (tight), t=1 (far) → zoom_min (wide).
+return zoom_max.lerp(zoom_min, t)
+
+
+func _clamp_to_stage(x: float, zoom_level: float) -> float:
+var half_visible_width := _viewport_size.x / (2.0 * zoom_level)
+var min_x := stage_left + half_visible_width
+var max_x := stage_right - half_visible_width
+if min_x > max_x:
+# Stage narrower than visible area — just center it.
+return (stage_left + stage_right) / 2.0
+return clampf(x, min_x, max_x)


### PR DESCRIPTION
## Camera Follow System (Closes #67)

Adds a dedicated CameraController script (camera_controller.gd) attached to the fight scene Camera2D.

### What it does
- **Follows both fighters** — centers between their positions
- **Distance-based zoom** — zooms tight when close (1.3x), wide when far (0.75x), smooth continuous range
- **Smooth interpolation** — position lerp (0.08) and zoom lerp (0.06), no jerky movement
- **Stage boundary clamping** — camera never shows beyond stage edges, adapts to current zoom level

### Files changed
- **NEW** \\games/ashfall/scripts/systems/camera_controller.gd\\ — CameraController class extending Camera2D
- **MOD** \\games/ashfall/scenes/main/fight_scene.tscn\\ — attaches camera_controller script to Camera2D node with stage boundary exports

### Validation
- Godot 4.6.1 headless: **exit code 0, no errors**