### PR TITLE
feat: implement throw state with tech/break mechanic

### DIFF
--- a/games/ashfall/scripts/fighters/fighter_base.gd
+++ b/games/ashfall/scripts/fighters/fighter_base.gd
@@ -70,8 +70,8 @@ func _update_facing() -> void:
 	if not opponent or not state_machine.current_state:
 		return
 	var state_name := state_machine.current_state.name.to_lower()
-	# Don't flip mid-attack, mid-hitstun, or when KO'd
-	if state_name in ["attack", "hit", "ko"]:
+	# Don't flip mid-attack, mid-hitstun, mid-throw, or when KO'd
+	if state_name in ["attack", "hit", "ko", "throw"]:
 		return
 	if global_position.x < opponent.global_position.x:
 		facing_direction = 1

--- a/games/ashfall/scripts/fighters/fighter_controller.gd
+++ b/games/ashfall/scripts/fighters/fighter_controller.gd
@@ -29,7 +29,7 @@ func _physics_process(_delta: float) -> void:
 	var current_state: String = _get_current_state()
 
 	# Don't process input during uninterruptible states
-	if current_state in ["hit", "ko", "launch", "block", "attack"]:
+	if current_state in ["hit", "ko", "launch", "block", "attack", "throw"]:
 		return
 
 	# Only ground attacks for M1 (no air specials)
@@ -49,7 +49,7 @@ func _try_throw() -> bool:
 	if input_buffer.check_simultaneous(["lp", "lk"]):
 		input_buffer.consume_button("lp")
 		input_buffer.consume_button("lk")
-		# TODO: transition to throw state when implemented
+		fighter.state_machine.transition_to("throw", {})
 		return true
 	return false
 


### PR DESCRIPTION
## Summary
Implements the throw state for the fighter state machine, completing the TODO in fighter_controller.gd.

## What's Built
- **throw_state.gd**: 5-phase throw with startup (5f) → active grab (2f) → execute (20f) or whiff recovery (15f)
- **Throw tech/break**: Opponent can escape by inputting LP+LK during startup window + first active frame
- **Frame data**: 120 damage, 280/-120 knockback, 70px throw range, 15f whiff recovery (punishable)
- **Controller wiring**: Replaces TODO with actual state transition, blocks input during throw
- **Fighter base**: Prevents facing direction flip during throw execution

## Files Changed
- \games/ashfall/scripts/fighters/states/throw_state.gd\ — New throw state (added in prior commit)
- \games/ashfall/scripts/fighters/fighter_controller.gd\ — Wire throw transition, add to uninterruptible states
- \games/ashfall/scripts/fighters/fighter_base.gd\ — Prevent facing flip during throw

## Validation
- ✅ Godot 4.6.1 headless loads project without errors (exit code 0)

Closes #62