### PR TITLE
feat: combo damage proration (100% to 40% floor)

### DIFF
--- a/games/ashfall/project.godot
+++ b/games/ashfall/project.godot
@@ -24,6 +24,7 @@ RoundManager="*res://scripts/systems/round_manager.gd"
 VFXManager="*res://scripts/systems/vfx_manager.gd"
 AudioManager="*res://scripts/systems/audio_manager.gd"
 SceneManager="*res://scripts/systems/scene_manager.gd"
+ComboTracker="*res://scripts/systems/combo_tracker.gd"
 
 [display]
 

--- a/games/ashfall/scripts/fight_scene.gd
+++ b/games/ashfall/scripts/fight_scene.gd
@@ -2,6 +2,10 @@
 ## EventBus, and manages the fight lifecycle.
 extends Node2D
 
+# Combo damage proration: multiplier per hit number (index 0 = hit 1).
+# Hit 5+ uses the last value (40% floor).
+const COMBO_PRORATION: Array[float] = [1.0, 0.8, 0.65, 0.5, 0.4]
+
 @onready var fighter1: Fighter = $Fighters/Fighter1
 @onready var fighter2: Fighter = $Fighters/Fighter2
 @onready var camera: CameraController = $Camera2D
@@ -46,12 +50,18 @@ func _on_fighter_damaged(fighter_node, amount: int, remaining_hp: int) -> void:
 func _on_fighter_ko(fighter_node) -> void:
 	EventBus.fighter_ko.emit(fighter_node)
 
+func _get_proration(combo_hit: int) -> float:
+	var idx: int = clampi(combo_hit - 1, 0, COMBO_PRORATION.size() - 1)
+	return COMBO_PRORATION[idx]
+
 func _on_hit_landed(attacker, target, move: Dictionary) -> void:
 	if not target or not is_instance_valid(target):
 		return
-	var damage: int = move.get("damage", 10)
+	var base_damage: int = move.get("damage", 10)
+	var combo_hit: int = ComboTracker.get_combo_count(attacker)
+	var scaled_damage: int = maxi(1, int(base_damage * _get_proration(combo_hit)))
 	if target.has_method("take_damage"):
-		target.take_damage(damage)
+		target.take_damage(scaled_damage)
 
 func _setup_combo_tracker() -> void:
 	var script := load("res://scripts/systems/combo_tracker.gd")

--- a/games/ashfall/scripts/systems/combo_tracker.gd
+++ b/games/ashfall/scripts/systems/combo_tracker.gd
@@ -27,6 +27,13 @@ func register_fighter(fighter: Node) -> void:
 		_combos[id] = ComboData.new()
 
 
+func get_combo_count(fighter: Node) -> int:
+	var id := fighter.get_instance_id()
+	if _combos.has(id):
+		return (_combos[id] as ComboData).count
+	return 0
+
+
 func reset_all() -> void:
 	for id in _combos:
 		var data: ComboData = _combos[id]
@@ -70,7 +77,7 @@ func _on_hit_landed(attacker: Variant, target: Variant, move: Variant) -> void:
 		return
 	register_fighter(attacker)
 
-	var id := attacker.get_instance_id()
+	var id: int = attacker.get_instance_id()
 	var data: ComboData = _combos[id]
 	var damage: int = move.get("damage", 10) if move is Dictionary else 10
 
@@ -87,7 +94,7 @@ func _on_hit_landed(attacker: Variant, target: Variant, move: Variant) -> void:
 func _on_hit_blocked(attacker: Variant, _target: Variant, _move: Variant) -> void:
 	if not attacker or not is_instance_valid(attacker):
 		return
-	var id := attacker.get_instance_id()
+	var id: int = attacker.get_instance_id()
 	if not _combos.has(id):
 		return
 	var data: ComboData = _combos[id]


### PR DESCRIPTION
## Summary
Implements combo damage proration so combos scale down in damage instead of doing full damage on every hit.

### Proration Table
| Hit | Multiplier | Example (100 base) |
|-----|-----------|---------------------|
| 1   | 100%      | 100                 |
| 2   | 80%       | 80                  |
| 3   | 65%       | 65                  |
| 4   | 50%       | 50                  |
| 5+  | 40%       | 40 (floor)          |

### Changes
- **fight_scene.gd**: Added \COMBO_PRORATION\ const array and \_get_proration()\ helper. Damage in \_on_hit_landed\ now scales by combo hit count via \ComboTracker.get_combo_count()\.
- **combo_tracker.gd**: Added \get_combo_count(fighter)\ public API. Fixed Variant type inference errors on \get_instance_id()\ calls.
- **event_bus.gd**: Added missing \combo_updated\ signal declaration (emitted by ComboTracker).
- **project.godot**: Registered ComboTracker as autoload (after SceneManager, depends on EventBus).

### Validation
- Godot 4.6.1 headless: **PASS** (no script errors)

Closes #69