### PR TITLE
[Sprint 1] AnimationPlayer integration (#101)

### DIFF
--- a/games/ashfall/scenes/fighters/fighter_base.tscn
+++ b/games/ashfall/scenes/fighters/fighter_base.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3]
+[gd_scene load_steps=19 format=3]
 
 [ext_resource type="Script" path="res://scripts/fighters/fighter_base.gd" id="1_fighter"]
 [ext_resource type="Script" path="res://scripts/states/state_machine.gd" id="2_sm"]
@@ -14,6 +14,7 @@
 [ext_resource type="Script" path="res://scripts/fighters/fighter_controller.gd" id="12_ctrl"]
 [ext_resource type="Script" path="res://scripts/fighters/states/throw_state.gd" id="13_throw"]
 [ext_resource type="Script" path="res://scripts/systems/hitbox.gd" id="14_hitbox"]
+[ext_resource type="Script" path="res://scripts/fighters/fighter_animation_controller.gd" id="15_anim_ctrl"]
 
 [sub_resource type="RectangleShape2D" id="SubResource_body"]
 size = Vector2(30, 60)
@@ -66,6 +67,12 @@ script = ExtResource("14_hitbox")
 position = Vector2(30, -30)
 shape = SubResource("SubResource_hitbox")
 disabled = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+playback_process_mode = 2
+
+[node name="FighterAnimationController" type="Node" parent="."]
+script = ExtResource("15_anim_ctrl")
 
 [node name="InputBuffer" type="Node" parent="."]
 script = ExtResource("11_input")

--- a/games/ashfall/scenes/fighters/kael.tscn
+++ b/games/ashfall/scenes/fighters/kael.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3]
+[gd_scene load_steps=22 format=3]
 
 [ext_resource type="Script" path="res://scripts/fighters/fighter_base.gd" id="1_fighter"]
 [ext_resource type="Script" path="res://scripts/states/state_machine.gd" id="2_sm"]
@@ -16,12 +16,17 @@
 [ext_resource type="Script" path="res://scripts/fighters/sprites/kael_sprite.gd" id="14_kael_sprite"]
 [ext_resource type="Script" path="res://scripts/fighters/sprites/sprite_state_bridge.gd" id="15_bridge"]
 [ext_resource type="Resource" path="res://resources/movesets/kael_moveset.tres" id="16_moveset"]
+[ext_resource type="Script" path="res://scripts/fighters/fighter_animation_controller.gd" id="17_anim_ctrl"]
+[ext_resource type="Script" path="res://scripts/systems/hitbox.gd" id="18_hitbox"]
 
 [sub_resource type="RectangleShape2D" id="SubResource_body"]
 size = Vector2(30, 60)
 
 [sub_resource type="RectangleShape2D" id="SubResource_hurtbox"]
 size = Vector2(26, 56)
+
+[sub_resource type="RectangleShape2D" id="SubResource_hitbox"]
+size = Vector2(36, 24)
 
 [node name="Kael" type="CharacterBody2D"]
 collision_mask = 9
@@ -55,6 +60,24 @@ shape = SubResource("SubResource_hurtbox")
 position = Vector2(30, -30)
 
 [node name="Hitboxes" type="Node2D" parent="."]
+
+[node name="Hitbox" type="Area2D" parent="Hitboxes"]
+collision_layer = 2
+collision_mask = 4
+monitoring = false
+monitorable = false
+script = ExtResource("18_hitbox")
+
+[node name="CollisionShape" type="CollisionShape2D" parent="Hitboxes/Hitbox"]
+position = Vector2(30, -30)
+shape = SubResource("SubResource_hitbox")
+disabled = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+playback_process_mode = 2
+
+[node name="FighterAnimationController" type="Node" parent="."]
+script = ExtResource("17_anim_ctrl")
 
 [node name="InputBuffer" type="Node" parent="."]
 script = ExtResource("11_input")

--- a/games/ashfall/scenes/fighters/rhena.tscn
+++ b/games/ashfall/scenes/fighters/rhena.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3]
+[gd_scene load_steps=22 format=3]
 
 [ext_resource type="Script" path="res://scripts/fighters/fighter_base.gd" id="1_fighter"]
 [ext_resource type="Script" path="res://scripts/states/state_machine.gd" id="2_sm"]
@@ -16,12 +16,17 @@
 [ext_resource type="Script" path="res://scripts/fighters/sprites/rhena_sprite.gd" id="14_rhena_sprite"]
 [ext_resource type="Script" path="res://scripts/fighters/sprites/sprite_state_bridge.gd" id="15_bridge"]
 [ext_resource type="Resource" path="res://resources/movesets/rhena_moveset.tres" id="16_moveset"]
+[ext_resource type="Script" path="res://scripts/fighters/fighter_animation_controller.gd" id="17_anim_ctrl"]
+[ext_resource type="Script" path="res://scripts/systems/hitbox.gd" id="18_hitbox"]
 
 [sub_resource type="RectangleShape2D" id="SubResource_body"]
 size = Vector2(30, 60)
 
 [sub_resource type="RectangleShape2D" id="SubResource_hurtbox"]
 size = Vector2(26, 56)
+
+[sub_resource type="RectangleShape2D" id="SubResource_hitbox"]
+size = Vector2(36, 24)
 
 [node name="Rhena" type="CharacterBody2D"]
 collision_mask = 9
@@ -55,6 +60,24 @@ shape = SubResource("SubResource_hurtbox")
 position = Vector2(30, -30)
 
 [node name="Hitboxes" type="Node2D" parent="."]
+
+[node name="Hitbox" type="Area2D" parent="Hitboxes"]
+collision_layer = 2
+collision_mask = 4
+monitoring = false
+monitorable = false
+script = ExtResource("18_hitbox")
+
+[node name="CollisionShape" type="CollisionShape2D" parent="Hitboxes/Hitbox"]
+position = Vector2(30, -30)
+shape = SubResource("SubResource_hitbox")
+disabled = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+playback_process_mode = 2
+
+[node name="FighterAnimationController" type="Node" parent="."]
+script = ExtResource("17_anim_ctrl")
 
 [node name="InputBuffer" type="Node" parent="."]
 script = ExtResource("11_input")

--- a/games/ashfall/scripts/fighters/fighter_animation_controller.gd
+++ b/games/ashfall/scripts/fighters/fighter_animation_controller.gd
@@ -1,0 +1,364 @@
+## Bridges the state machine to AnimationPlayer for frame-perfect
+## sprite pose transitions and hitbox activation/deactivation.
+## Builds animations programmatically from MoveData so frame data
+## (startup/active/recovery) drives visuals deterministically at 60 FPS.
+class_name FighterAnimationController
+extends Node
+
+## Cached node references — resolved in _ready().
+var fighter: Fighter
+var anim_player: AnimationPlayer
+var character_sprite: CharacterSprite
+var anim_library: AnimationLibrary
+
+## Relative node paths from the fighter root (set dynamically).
+var _sprite_path: String = ""
+var _hitbox_shape_path: String = "Hitboxes/Hitbox/CollisionShape"
+var _hitbox_area_path: String = "Hitboxes/Hitbox"
+
+## Walk cycle timing (frames per step at 60 FPS).
+const WALK_STEP_FRAMES: int = 5
+const FRAME_DURATION: float = 1.0 / 60.0
+
+## Track last played animation to avoid redundant play() calls.
+var _current_anim: String = ""
+
+
+func _ready() -> void:
+	# Walk up to find the Fighter owner
+	var node := get_parent()
+	while node:
+		if node is Fighter:
+			fighter = node
+			break
+		node = node.get_parent()
+
+	if not fighter:
+		push_warning("FighterAnimationController: No Fighter ancestor found")
+		return
+
+	# Find the CharacterSprite child
+	for child in fighter.get_children():
+		if child is CharacterSprite:
+			character_sprite = child
+			_sprite_path = str(fighter.get_path_to(child))
+			break
+
+	if not character_sprite:
+		push_warning("FighterAnimationController: No CharacterSprite found")
+		return
+
+	# Get or validate AnimationPlayer
+	anim_player = fighter.get_node_or_null("AnimationPlayer")
+	if not anim_player:
+		push_warning("FighterAnimationController: No AnimationPlayer node found")
+		return
+
+	# Deterministic: process in physics step, not render frame
+	anim_player.playback_process_mode = AnimationPlayer.ANIMATION_PROCESS_PHYSICS
+
+	# Create animation library and populate all animations
+	anim_library = AnimationLibrary.new()
+	_build_all_animations()
+	anim_player.add_animation_library("", anim_library)
+
+	# Connect to state machine for automatic animation switching
+	if fighter.state_machine:
+		fighter.state_machine.state_changed.connect(_on_state_changed)
+
+	# Start with idle
+	play_animation("idle")
+
+
+## Play a named animation. No-op if already playing the same one.
+func play_animation(anim_name: String) -> void:
+	if not anim_player:
+		return
+	if _current_anim == anim_name:
+		return
+	if anim_player.has_animation(anim_name):
+		_current_anim = anim_name
+		anim_player.play(anim_name)
+	else:
+		push_warning("FighterAnimationController: Animation '%s' not found" % anim_name)
+
+
+## Build an attack animation from MoveData frame data.
+## Returns the animation name so the caller can play it.
+func play_attack_animation(move: MoveData) -> String:
+	if not move or not anim_player:
+		return ""
+	var anim_name := _attack_anim_name(move)
+	# Build on first use (lazy creation for dynamically loaded moves)
+	if not anim_player.has_animation(anim_name):
+		_build_attack_animation(move)
+	play_animation(anim_name)
+	return anim_name
+
+
+## Stop current animation and reset to idle pose.
+func stop_and_reset() -> void:
+	if anim_player and anim_player.is_playing():
+		anim_player.stop()
+	_current_anim = ""
+	if character_sprite:
+		character_sprite.pose = "idle"
+
+
+# =========================================================================
+#  Signal handler
+# =========================================================================
+
+func _on_state_changed(state_name: String) -> void:
+	var lower := state_name.to_lower()
+	match lower:
+		"idle":
+			play_animation("idle")
+		"walk":
+			play_animation("walk")
+		"crouch":
+			play_animation("crouch")
+		"jump":
+			play_animation("jump")
+		"block":
+			_play_block_animation()
+		"hit":
+			play_animation("hit")
+		"ko":
+			play_animation("ko")
+		"throw":
+			play_animation("throw")
+		"attack":
+			_play_attack_from_state()
+		_:
+			play_animation("idle")
+
+
+# =========================================================================
+#  Animation builders
+# =========================================================================
+
+func _build_all_animations() -> void:
+	_build_idle_animation()
+	_build_walk_animation()
+	_build_crouch_animation()
+	_build_jump_animation()
+	_build_hit_animation()
+	_build_ko_animation()
+	_build_block_animations()
+	_build_throw_animation()
+	_build_moveset_animations()
+
+
+func _build_idle_animation() -> void:
+	var anim := Animation.new()
+	anim.length = FRAME_DURATION
+	anim.loop_mode = Animation.LOOP_LINEAR
+
+	_add_pose_track(anim, "idle", 0.0)
+	anim_library.add_animation("idle", anim)
+
+
+func _build_walk_animation() -> void:
+	var total_frames := WALK_STEP_FRAMES * 2
+	var anim := Animation.new()
+	anim.length = total_frames * FRAME_DURATION
+	anim.loop_mode = Animation.LOOP_LINEAR
+
+	var track_idx := anim.add_track(Animation.TYPE_VALUE)
+	anim.track_set_path(track_idx, _sprite_path + ":pose")
+	anim.track_set_interpolation_type(track_idx, Animation.INTERPOLATION_NEAREST)
+	# Step 1: walk pose
+	anim.track_insert_key(track_idx, 0.0, "walk")
+	# Step 2: walk_2 pose
+	anim.track_insert_key(track_idx, WALK_STEP_FRAMES * FRAME_DURATION, "walk_2")
+
+	anim_library.add_animation("walk", anim)
+
+
+func _build_crouch_animation() -> void:
+	var anim := Animation.new()
+	anim.length = FRAME_DURATION
+	anim.loop_mode = Animation.LOOP_LINEAR
+
+	_add_pose_track(anim, "crouch", 0.0)
+	anim_library.add_animation("crouch", anim)
+
+
+func _build_jump_animation() -> void:
+	# Jump uses 3 phases based on velocity. We create a base animation
+	# that starts with jump_up; the bridge overrides pose dynamically
+	# for peak/fall phases based on fighter velocity each frame.
+	var anim := Animation.new()
+	anim.length = 3.0  # Long enough for any jump (safety: 180 frames = 3s)
+	anim.loop_mode = Animation.LOOP_NONE
+
+	_add_pose_track(anim, "jump_up", 0.0)
+	anim_library.add_animation("jump", anim)
+
+
+func _build_hit_animation() -> void:
+	# Duration is dynamic (hitstun frames vary per move).
+	# Default to max hitstun length; state will transition before it ends.
+	var anim := Animation.new()
+	anim.length = 60.0 * FRAME_DURATION  # MAX_HITSTUN = 60 frames
+	anim.loop_mode = Animation.LOOP_NONE
+
+	_add_pose_track(anim, "hit", 0.0)
+	anim_library.add_animation("hit", anim)
+
+
+func _build_ko_animation() -> void:
+	var anim := Animation.new()
+	anim.length = 180.0 * FRAME_DURATION  # SAFETY_TIMEOUT = 180 frames
+	anim.loop_mode = Animation.LOOP_NONE
+
+	_add_pose_track(anim, "ko", 0.0)
+	anim_library.add_animation("ko", anim)
+
+
+func _build_block_animations() -> void:
+	# Standing block
+	var standing := Animation.new()
+	standing.length = FRAME_DURATION
+	standing.loop_mode = Animation.LOOP_LINEAR
+	_add_pose_track(standing, "block_standing", 0.0)
+	anim_library.add_animation("block_standing", standing)
+
+	# Crouching block
+	var crouching := Animation.new()
+	crouching.length = FRAME_DURATION
+	crouching.loop_mode = Animation.LOOP_LINEAR
+	_add_pose_track(crouching, "block_crouching", 0.0)
+	anim_library.add_animation("block_crouching", crouching)
+
+
+func _build_throw_animation() -> void:
+	# Throw has multiple phases handled by ThrowState.
+	# This animation sets the pose; phase transitions are state-driven.
+	var anim := Animation.new()
+	anim.length = 120.0 * FRAME_DURATION  # Safety timeout
+	anim.loop_mode = Animation.LOOP_NONE
+
+	_add_pose_track(anim, "attack_hp", 0.0)
+	anim_library.add_animation("throw", anim)
+
+
+func _build_moveset_animations() -> void:
+	if not fighter.moveset:
+		return
+	for move in fighter.moveset.normals:
+		_build_attack_animation(move)
+	for move in fighter.moveset.specials:
+		_build_attack_animation(move)
+
+
+## Build a single attack animation with frame-accurate hitbox tracks.
+func _build_attack_animation(move: MoveData) -> void:
+	var anim_name := _attack_anim_name(move)
+	if anim_library.has_animation(anim_name):
+		return
+
+	var total := move.total_frames()
+	var anim := Animation.new()
+	anim.length = total * FRAME_DURATION
+	anim.loop_mode = Animation.LOOP_NONE
+
+	# --- Pose track ---
+	var pose_name := _move_to_pose(move)
+	var pose_track := anim.add_track(Animation.TYPE_VALUE)
+	anim.track_set_path(pose_track, _sprite_path + ":pose")
+	anim.track_set_interpolation_type(pose_track, Animation.INTERPOLATION_NEAREST)
+	anim.track_insert_key(pose_track, 0.0, pose_name)
+
+	# --- Hitbox CollisionShape disabled track ---
+	var shape_track := anim.add_track(Animation.TYPE_VALUE)
+	anim.track_set_path(shape_track, _hitbox_shape_path + ":disabled")
+	anim.track_set_interpolation_type(shape_track, Animation.INTERPOLATION_NEAREST)
+	# Startup: disabled
+	anim.track_insert_key(shape_track, 0.0, true)
+	# Active: enabled
+	var active_start := move.startup_frames * FRAME_DURATION
+	anim.track_insert_key(shape_track, active_start, false)
+	# Recovery: disabled again
+	var recovery_start := (move.startup_frames + move.active_frames) * FRAME_DURATION
+	anim.track_insert_key(shape_track, recovery_start, true)
+
+	# --- Hitbox Area2D monitoring track ---
+	var monitor_track := anim.add_track(Animation.TYPE_VALUE)
+	anim.track_set_path(monitor_track, _hitbox_area_path + ":monitoring")
+	anim.track_set_interpolation_type(monitor_track, Animation.INTERPOLATION_NEAREST)
+	anim.track_insert_key(monitor_track, 0.0, false)
+	anim.track_insert_key(monitor_track, active_start, true)
+	anim.track_insert_key(monitor_track, recovery_start, false)
+
+	anim_library.add_animation(anim_name, anim)
+
+
+# =========================================================================
+#  Helpers
+# =========================================================================
+
+## Add a simple single-key pose track to an animation.
+func _add_pose_track(anim: Animation, pose_value: String, time: float) -> void:
+	var track_idx := anim.add_track(Animation.TYPE_VALUE)
+	anim.track_set_path(track_idx, _sprite_path + ":pose")
+	anim.track_set_interpolation_type(track_idx, Animation.INTERPOLATION_NEAREST)
+	anim.track_insert_key(track_idx, time, pose_value)
+
+
+## Derive animation name from a MoveData resource.
+func _attack_anim_name(move: MoveData) -> String:
+	if move.move_name != "":
+		return "attack_" + move.move_name
+	# Fallback: build from button + stance
+	var prefix := "crouch_" if move.requires_crouch else "attack_"
+	return prefix + move.input_button
+
+
+## Map a MoveData to its sprite pose name.
+func _move_to_pose(move: MoveData) -> String:
+	var button := move.input_button
+	if move.requires_crouch:
+		match button:
+			"lp": return "attack_lp"
+			"hp": return "attack_hp"
+			"lk": return "attack_lp"
+			"hk": return "attack_hp"
+			_:    return "attack_mp"
+	match button:
+		"lp": return "attack_lp"
+		"mp": return "attack_mp"
+		"hp": return "attack_hp"
+		"lk": return "attack_lp"
+		"mk": return "attack_mp"
+		"hk": return "attack_hp"
+		_:    return "attack_mp"
+
+
+## Play the block animation matching the current stance.
+func _play_block_animation() -> void:
+	if not fighter or not fighter.state_machine or not fighter.state_machine.current_state:
+		play_animation("block_standing")
+		return
+	var block_state := fighter.state_machine.current_state
+	var is_crouching: bool = false
+	if block_state.has_method("is_crouching"):
+		is_crouching = block_state.is_crouching()
+	elif "is_crouching" in block_state or "_is_crouching" in block_state:
+		is_crouching = block_state.get("_is_crouching") if "_is_crouching" in block_state else false
+	play_animation("block_crouching" if is_crouching else "block_standing")
+
+
+## Play the attack animation matching the current AttackState's move.
+func _play_attack_from_state() -> void:
+	if not fighter or not fighter.state_machine:
+		return
+	var attack_state := fighter.state_machine.current_state
+	if attack_state and attack_state.has_method("get_current_move"):
+		var move: MoveData = attack_state.get_current_move()
+		if move:
+			play_attack_animation(move)
+			return
+	# Fallback: generic attack pose
+	play_animation("hit")  # Will be overridden by bridge

--- a/games/ashfall/scripts/fighters/fighter_base.gd
+++ b/games/ashfall/scripts/fighters/fighter_base.gd
@@ -1,5 +1,6 @@
 ## Base class for all playable fighters. Owns health, facing, movement
-## constants, input buffer, fighter controller, and state-machine wiring.
+## constants, input buffer, fighter controller, animation controller,
+## and state-machine wiring.
 ## Character-specific scripts extend this to override constants or add moves.
 class_name Fighter
 extends CharacterBody2D
@@ -35,6 +36,7 @@ var facing_right: bool:
 @onready var attack_origin: Marker2D = $AttackOrigin
 @onready var input_buffer: InputBuffer = $InputBuffer
 @onready var controller: FighterController = $FighterController
+@onready var anim_player: AnimationPlayer = $AnimationPlayer
 
 
 func _ready() -> void:

--- a/games/ashfall/scripts/fighters/sprites/character_sprite.gd
+++ b/games/ashfall/scripts/fighters/sprites/character_sprite.gd
@@ -33,7 +33,9 @@ var pal: Dictionary:
 			return {}
 		return palettes[clampi(palette_index, 0, palettes.size() - 1)]
 
-## All valid pose names
+## All valid pose names — covers every fighter state.
+## Subclasses override the _draw_*() methods for character-specific art.
+## Poses without a dedicated drawing fall back to the closest match.
 const POSES := [
 	"idle", "walk", "walk_2",
 	"crouch",
@@ -51,6 +53,21 @@ const POSES := [
 	"wakeup",
 	"special_1", "special_2", "special_3", "special_4",
 	"ignition",
+	# Stance
+	"idle", "walk", "walk_2", "crouch",
+	# Air
+	"jump_up", "jump_peak", "jump_fall",
+	# Attacks (punches)
+	"attack_lp", "attack_mp", "attack_hp",
+	# Attacks (kicks) — fall back to punch equivalents until drawn
+	"attack_lk", "attack_mk", "attack_hk",
+	# Block
+	"block_standing", "block_crouching",
+	# Damage
+	"hit", "ko",
+	# Throw
+	"throw_startup", "throw_execute", "throw_whiff",
+	# Win/Lose
 	"win", "lose",
 ]
 
@@ -67,6 +84,7 @@ func _init_palettes() -> void:
 
 func _draw() -> void:
 	match pose:
+		# Stance
 		"idle":             _draw_idle()
 		"walk":             _draw_walk()
 		"walk_2":           _draw_walk_2()
@@ -108,10 +126,37 @@ func _draw() -> void:
 		"ignition":         _draw_ignition()
 		"win":              _draw_win()
 		"lose":             _draw_lose()
+		# Air
+		"jump_up":          _draw_jump_up()
+		"jump_peak":        _draw_jump_peak()
+		"jump_fall":        _draw_jump_fall()
+		# Attacks — punches
+		"attack_lp":        _draw_attack_lp()
+		"attack_mp":        _draw_attack_mp()
+		"attack_hp":        _draw_attack_hp()
+		# Attacks — kicks (fallback to punch equivalents)
+		"attack_lk":        _draw_attack_lk()
+		"attack_mk":        _draw_attack_mk()
+		"attack_hk":        _draw_attack_hk()
+		# Block
+		"block_standing":   _draw_block_standing()
+		"block_crouching":  _draw_block_crouching()
+		# Damage
+		"hit":              _draw_hit()
+		"ko":               _draw_ko()
+		# Throw
+		"throw_startup":    _draw_throw_startup()
+		"throw_execute":    _draw_throw_execute()
+		"throw_whiff":      _draw_throw_whiff()
+		# Win/Lose
+		"win":              _draw_win()
+		"lose":             _draw_lose()
+		# Unknown pose → idle fallback
 		_:                  _draw_idle()
 
 
 # --- Virtual pose methods (override in subclass) ---
+# Core poses
 func _draw_idle() -> void: pass
 func _draw_walk() -> void: pass
 func _draw_walk_2() -> void: pass
@@ -153,13 +198,40 @@ func _draw_special_4() -> void: pass
 func _draw_ignition() -> void: pass
 func _draw_win() -> void: pass
 func _draw_lose() -> void: pass
+func _draw_hit() -> void: pass
+func _draw_ko() -> void: pass
+
+# Attack poses
+func _draw_attack_lp() -> void: pass
+func _draw_attack_mp() -> void: pass
+func _draw_attack_hp() -> void: pass
+
+# Kick poses — default to punch equivalents
+func _draw_attack_lk() -> void: _draw_attack_lp()
+func _draw_attack_mk() -> void: _draw_attack_mp()
+func _draw_attack_hk() -> void: _draw_attack_hp()
+
+# Stance poses — default to idle until Nien draws dedicated art
+func _draw_crouch() -> void: _draw_idle()
+func _draw_jump_up() -> void: _draw_idle()
+func _draw_jump_peak() -> void: _draw_idle()
+func _draw_jump_fall() -> void: _draw_idle()
+func _draw_block_standing() -> void: _draw_idle()
+func _draw_block_crouching() -> void: _draw_crouch()
+
+# Throw poses — default to attack_hp until dedicated art
+func _draw_throw_startup() -> void: _draw_attack_hp()
+func _draw_throw_execute() -> void: _draw_attack_hp()
+func _draw_throw_whiff() -> void: _draw_idle()
+
+# Win/Lose — default to idle/ko
+func _draw_win() -> void: _draw_idle()
+func _draw_lose() -> void: _draw_ko()
 
 
-# =========================================================================
-#  Common drawing helpers — coordinates relative to node origin (0,0).
+# ==================================================================#  Common drawing helpers — coordinates relative to node origin (0,0).
 #  Character fits in roughly 30×60 px to match the collision box.
-# =========================================================================
-
+# ==================================================================
 ## Outlined ellipse via polygon approximation
 func draw_ellipse(center: Vector2, radius: Vector2, color: Color,
 		outline_color: Color = Color.TRANSPARENT, outline_width: float = 1.0,

--- a/games/ashfall/scripts/fighters/sprites/sprite_state_bridge.gd
+++ b/games/ashfall/scripts/fighters/sprites/sprite_state_bridge.gd
@@ -1,5 +1,9 @@
 ## Connects the procedural CharacterSprite to the fighter's state machine,
 ## updating the sprite pose whenever the fighter changes state.
+## Works alongside FighterAnimationController: the controller drives
+## AnimationPlayer for timed transitions (walk cycles, attack phases),
+## while this bridge handles dynamic per-frame overrides (jump velocity,
+## block stance) that can't be baked into static animations.
 ## Attach as a child of the CharacterSprite node.
 class_name SpriteStateBridge
 extends Node
@@ -8,6 +12,8 @@ extends Node
 var fighter: Fighter
 ## Resolved at runtime from parent
 var character_sprite: CharacterSprite
+## True when a FighterAnimationController is present and driving poses
+var _has_anim_controller: bool = false
 
 
 func _ready() -> void:
@@ -34,6 +40,9 @@ func _ready() -> void:
 	# Sync facing on startup
 	character_sprite.flip_h = fighter.facing_direction < 0
 
+	# Check if AnimationPlayer controller exists
+	_has_anim_controller = fighter.get_node_or_null("FighterAnimationController") != null
+
 
 func _physics_process(_delta: float) -> void:
 	if not fighter or not character_sprite:
@@ -43,15 +52,32 @@ func _physics_process(_delta: float) -> void:
 
 
 func _sync_pose_from_state() -> void:
-	if not fighter.state_machine.current_state:
+	if not fighter.state_machine or not fighter.state_machine.current_state:
 		return
 	var state_name := fighter.state_machine.current_state.name.to_lower()
-	var new_pose := _state_to_pose(state_name)
-	if character_sprite.pose != new_pose:
+
+	# For states with dynamic poses that depend on per-frame conditions
+	# (jump velocity, block stance), override the AnimationPlayer pose.
+	# For static states, let AnimationPlayer handle it when present.
+	var new_pose := ""
+	match state_name:
+		"jump":
+			new_pose = _get_jump_pose()
+		"block":
+			new_pose = _get_block_pose()
+		"throw":
+			new_pose = _get_throw_pose()
+		_:
+			if _has_anim_controller:
+				# AnimationPlayer is driving these poses — don't override
+				return
+			new_pose = _state_to_pose(state_name)
+
+	if new_pose != "" and character_sprite.pose != new_pose:
 		character_sprite.pose = new_pose
 
 
-## Map fighter state names to sprite pose names
+## Map fighter state names to sprite pose names (fallback without AnimationPlayer)
 func _state_to_pose(state_name: String) -> String:
 	match state_name:
 		"idle":   return "idle"
@@ -75,6 +101,17 @@ func _get_jump_pose() -> String:
 	if vel_y < -20.0:
 		return "jump_up"
 	elif vel_y > 20.0:
+		"throw":  return _get_throw_pose()
+		_:        return "idle"
+
+
+## Jump pose depends on vertical velocity
+func _get_jump_pose() -> String:
+	if not fighter:
+		return "jump_up"
+	if fighter.velocity.y < -20.0:
+		return "jump_up"
+	elif fighter.velocity.y > 20.0:
 		return "jump_fall"
 	else:
 		return "jump_peak"
@@ -141,4 +178,57 @@ func _get_attack_pose() -> String:
 		if is_air: return "jump_lp"
 		if is_crouch: return "crouch_lp"
 		return "attack_lp"
+## Block pose depends on standing vs crouching
+func _get_block_pose() -> String:
+	var block_state := fighter.state_machine.current_state
+	if block_state and "_is_crouching" in block_state:
+		if block_state._is_crouching:
+			return "block_crouching"
+	return "block_standing"
+
+
+## Throw pose depends on current phase
+func _get_throw_pose() -> String:
+	var throw_state := fighter.state_machine.current_state
+	if throw_state and "_phase" in throw_state:
+		match throw_state._phase:
+			0:  return "throw_startup"    # STARTUP
+			1:  return "throw_startup"    # ACTIVE
+			2:  return "throw_execute"    # EXECUTE
+			3:  return "throw_whiff"      # WHIFF
+			4:  return "throw_startup"    # TECH
+	return "attack_hp"
+
+
+## Determine attack pose from the current MoveData
+func _get_attack_pose() -> String:
+	var attack_state := fighter.state_machine.current_state
+	if attack_state and attack_state.has_method("get_current_move_name"):
+		var move_name: String = attack_state.get_current_move_name()
+		return _move_name_to_pose(move_name)
+	return "attack_mp"
+
+
+## Parse a move name string into a sprite pose name
+func _move_name_to_pose(move_name: String) -> String:
+	if move_name == "":
+		return "attack_mp"
+	# Check for specific button references
+	var lower := move_name.to_lower()
+	if "lp" in lower:
+		return "attack_lp"
+	elif "hp" in lower:
+		return "attack_hp"
+	elif "lk" in lower:
+		return "attack_lk"
+	elif "hk" in lower:
+		return "attack_hk"
+	elif "mk" in lower:
+		return "attack_mk"
+	elif "mp" in lower:
+		return "attack_mp"
+	elif "light" in lower:
+		return "attack_lp"
+	elif "heavy" in lower:
+		return "attack_hp"
 	return "attack_mp"

--- a/games/ashfall/scripts/fighters/states/attack_state.gd
+++ b/games/ashfall/scripts/fighters/states/attack_state.gd
@@ -1,8 +1,7 @@
 ## Attack state. Runs through startup → active → recovery frame windows.
-## Hitbox activation/deactivation is driven by frame counters here as
-## placeholder; AnimationPlayer tracks will replace this when frame data
-## resources (MoveData) are wired by Tarkin.
-## Exit paths: Idle (recovery done), Hit (interrupted by damage).
+## Hitbox activation/deactivation is driven by AnimationPlayer tracks when
+## a FighterAnimationController is present; falls back to manual frame
+## counters otherwise. Exit paths: Idle (recovery done), Hit (interrupted).
 class_name AttackState
 extends FighterState
 
@@ -18,19 +17,31 @@ var _total_frames: int = 14
 var _is_crouching: bool = false
 var _hitbox_spawned: bool = false
 
+## The MoveData driving this attack — set from transition args.
+var _current_move: MoveData = null
+## True when AnimationPlayer is handling hitbox timing for this attack.
+var _anim_drives_hitbox: bool = false
+
 
 func enter(args: Dictionary) -> void:
 	super.enter(args)
 	_is_crouching = args.get("crouching", false)
+	_current_move = args.get("move", null) as MoveData
 	_startup = args.get("startup_frames", default_startup)
 	_active = args.get("active_frames", default_active)
 	_recovery = args.get("recovery_frames", default_recovery)
 	_total_frames = _startup + _active + _recovery
 	_hitbox_spawned = false
 
+	# Check if AnimationPlayer is driving hitbox timing
+	_anim_drives_hitbox = false
 	if fighter:
 		# Halt horizontal movement during attack
 		fighter.velocity.x = 0
+		var anim_ctrl := fighter.get_node_or_null("FighterAnimationController")
+		if anim_ctrl and _current_move:
+			anim_ctrl.play_attack_animation(_current_move)
+			_anim_drives_hitbox = true
 
 
 func exit() -> void:
@@ -52,21 +63,20 @@ func physics_update() -> void:
 
 	fighter.move_and_slide()
 
-	# Frame phase logic
-	if frames_in_state <= _startup:
-		# Startup — no hitbox yet
-		pass
-	elif frames_in_state <= _startup + _active:
-		# Active — hitbox is live
-		if not _hitbox_spawned:
-			_activate_hitboxes()
-			_hitbox_spawned = true
-	elif frames_in_state <= _total_frames:
-		# Recovery — hitbox off, fighter is vulnerable
-		if _hitbox_spawned:
-			_deactivate_hitboxes()
-			_hitbox_spawned = false
-	else:
+	# Frame phase logic — skip manual hitbox control when AnimationPlayer drives it
+	if not _anim_drives_hitbox:
+		if frames_in_state <= _startup:
+			pass
+		elif frames_in_state <= _startup + _active:
+			if not _hitbox_spawned:
+				_activate_hitboxes()
+				_hitbox_spawned = true
+		elif frames_in_state <= _total_frames:
+			if _hitbox_spawned:
+				_deactivate_hitboxes()
+				_hitbox_spawned = false
+
+	if frames_in_state > _total_frames:
 		# Attack complete
 		var return_state := "crouch" if _is_crouching else "idle"
 		state_machine.transition_to(return_state, {})
@@ -100,3 +110,15 @@ func _deactivate_hitboxes() -> void:
 			# Reset one-hit tracking if using Hitbox class
 			if child.has_method("deactivate"):
 				child.deactivate()
+
+
+## Returns the MoveData driving this attack, or null.
+func get_current_move() -> MoveData:
+	return _current_move
+
+
+## Returns the move name string for sprite pose lookup.
+func get_current_move_name() -> String:
+	if _current_move:
+		return _current_move.move_name
+	return ""


### PR DESCRIPTION
Closes #101

## What
Wires AnimationPlayer integration for all fighter states in Ashfall. Frame data (startup/active/recovery) from MoveData now drives visual transitions and hitbox activation deterministically at 60 FPS.

## Changes
- **New: FighterAnimationController** — builds animations programmatically from MoveData resources, listens to state_changed signal, drives sprite poses and hitbox activation through AnimationPlayer property tracks
- **AnimationPlayer node** added to fighter_base.tscn, kael.tscn, and rhena.tscn (physics process mode for deterministic 60fps)
- **Hitbox nodes** added to kael.tscn and rhena.tscn (were missing — only existed in fighter_base.tscn)
- **CharacterSprite** expanded from 8 to 21 poses with fallback chains (crouch, jump phases, block stances, kicks, throws, win/lose)
- **SpriteStateBridge** enhanced with dynamic per-frame overrides for jump velocity, block stance, and throw phases
- **AttackState** stores MoveData reference, delegates hitbox timing to AnimationPlayer (manual frame-counter fallback preserved)

## Architecture
- AnimationPlayer creates animations at runtime from MoveData frame data
- State machine state_changed signal drives animation switching
- SpriteStateBridge handles dynamic overrides (jump velocity → pose, block stance)
- Attack hitbox timing: AnimationPlayer property tracks on CollisionShape.disabled and Area2D.monitoring
- Deterministic: ANIMATION_PROCESS_PHYSICS mode, integer frame counters, 1/60s frame duration