### PR TITLE
P0 Fix: Character select now responds to Enter/Space and arrow keys

### DIFF
--- a/games/ashfall/scenes/ui/character_select.tscn
+++ b/games/ashfall/scenes/ui/character_select.tscn
@@ -126,7 +126,7 @@ custom_minimum_size = Vector2(0, 8)
 [node name="P1StatusLabel" type="Label" parent="Panels/P1Panel/P1VBox"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "← A/D →  [U] Confirm"
+text = "← →  Enter to Confirm"
 horizontal_alignment = 1
 theme_override_colors/font_color = Color(1, 0.7, 0.2, 0.7)
 theme_override_font_sizes/font_size = 14
@@ -210,7 +210,7 @@ custom_minimum_size = Vector2(0, 8)
 [node name="P2StatusLabel" type="Label" parent="Panels/P2Panel/P2VBox"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "← ←/→ →  [Num4] Confirm"
+text = "← →  Numpad 4 to Confirm"
 horizontal_alignment = 1
 theme_override_colors/font_color = Color(1, 0.7, 0.2, 0.7)
 theme_override_font_sizes/font_size = 14

--- a/games/ashfall/scripts/ui/character_select.gd
+++ b/games/ashfall/scripts/ui/character_select.gd
@@ -1,5 +1,7 @@
-## Character select — two-panel selection with WASD (P1) and Arrows (P2).
-## Confirm with attack, back with block. Transitions to fight when both confirm.
+## Character select — two-panel selection with intuitive UI controls.
+## P1: Arrow keys / A,D to navigate, Enter/Space to confirm (also accepts fight keys).
+## P2 (vs_player): Arrow keys to navigate, Numpad Enter to confirm.
+## In vs_cpu mode P2 auto-mirrors P1. Transitions to fight when both confirm.
 extends Control
 
 const CHARACTERS := [
@@ -43,17 +45,27 @@ func _process(_delta: float) -> void:
 
 func _handle_p1_input() -> void:
 	if p1_confirmed:
-		if Input.is_action_just_pressed("p1_block"):
+		if Input.is_action_just_pressed("p1_block") or Input.is_action_just_pressed("ui_cancel"):
 			p1_confirmed = false
 			_update_display()
 		return
-	if Input.is_action_just_pressed("p1_left"):
+
+	var nav_left := Input.is_action_just_pressed("p1_left")
+	var nav_right := Input.is_action_just_pressed("p1_right")
+	# In vs_cpu mode arrow keys also control P1 (no P2 conflict)
+	if SceneManager.game_mode == "vs_cpu":
+		nav_left = nav_left or Input.is_action_just_pressed("ui_left")
+		nav_right = nav_right or Input.is_action_just_pressed("ui_right")
+
+	if nav_left:
 		p1_index = wrapi(p1_index - 1, 0, CHARACTERS.size())
 		_update_display()
-	elif Input.is_action_just_pressed("p1_right"):
+	elif nav_right:
 		p1_index = wrapi(p1_index + 1, 0, CHARACTERS.size())
 		_update_display()
-	if Input.is_action_just_pressed("p1_light_punch"):
+
+	# Accept Enter/Space (ui_accept) or fight button (p1_light_punch) to confirm
+	if Input.is_action_just_pressed("ui_accept") or Input.is_action_just_pressed("p1_light_punch"):
 		p1_confirmed = true
 		_update_display()
 
@@ -96,20 +108,25 @@ func _update_display() -> void:
 	p1_portrait.color = p1.color
 	p1_name_label.text = p1.name
 	p1_archetype_label.text = p1.archetype
-	p1_status_label.text = "READY!" if p1_confirmed else "← A/D →  [U] Confirm"
+	if SceneManager.game_mode == "vs_cpu":
+		p1_status_label.text = "READY!" if p1_confirmed else "← →  Enter to Confirm"
+	else:
+		p1_status_label.text = "READY!" if p1_confirmed else "← A/D →  Enter to Confirm"
 
 	p2_portrait.color = p2.color
 	p2_name_label.text = p2.name
 	p2_archetype_label.text = p2.archetype
 	if SceneManager.game_mode == "vs_cpu":
-		p2_status_label.text = "CPU" if p2_confirmed else "CPU"
+		p2_status_label.text = "CPU"
 	else:
-		p2_status_label.text = "READY!" if p2_confirmed else "← ←/→ →  [Num4] Confirm"
+		p2_status_label.text = "READY!" if p2_confirmed else "← →  Numpad 4 to Confirm"
 
 
 func _unhandled_input(event: InputEvent) -> void:
+	if _transitioning:
+		return
 	# Global back — go to main menu
-	if event.is_action_pressed("ui_cancel") and not _transitioning:
+	if event.is_action_pressed("ui_cancel"):
 		if p1_confirmed:
 			p1_confirmed = false
 			_update_display()


### PR DESCRIPTION
## Problem
The game was completely stuck at the character select screen. No keyboard input appeared to work - the game was unplayable.

## Root Cause
Character select only listened for fight controls to navigate and confirm:
- Navigate: p1_left (A key) / p1_right (D key)
- Confirm: p1_light_punch (U key)

No one would intuitively press U to confirm a character selection.

## Fix
- Enter/Space (ui_accept) now confirms P1 character selection in all modes
- Arrow keys (ui_left/ui_right) now navigate P1 in vs_cpu mode
- Escape (ui_cancel) can un-confirm P1 selection
- Updated hint labels to show intuitive controls
- Added transitioning guard to unhandled_input
- P2 controls in vs_player mode remain unchanged

## Files Changed
- games/ashfall/scripts/ui/character_select.gd - input handling + display logic
- games/ashfall/scenes/ui/character_select.tscn - default hint label text

## Testing
- Main menu -> VS CPU -> arrow keys navigate -> Enter confirms -> transitions to fight
- Main menu -> VS Player -> A/D navigate P1, arrows navigate P2
- Escape backs out of confirmed state, then back to main menu
- Full flow: MainMenu -> CharacterSelect -> Fight verified working