### PR TITLE
fix: character select keyboard input — v3 (two root causes)

### DIFF
--- a/.github/workflows/godot-release.yml
+++ b/.github/workflows/godot-release.yml
@@ -51,6 +51,13 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "tag_clean=${TAG#ashfall-}" >> $GITHUB_OUTPUT
       
+      - name: Import project
+        working-directory: games/ashfall
+        run: |
+          godot --headless --import
+          # Wait for import to complete
+          sleep 2
+
       - name: Export Windows build
         working-directory: games/ashfall
         run: |

--- a/games/ashfall/scripts/ui/character_select.gd
+++ b/games/ashfall/scripts/ui/character_select.gd
@@ -29,12 +29,13 @@ var _transitioning: bool = false
 
 
 func _ready() -> void:
+	set_process_input(true)
 	_update_display()
 	var mode_text := "VS CPU" if SceneManager.game_mode == "vs_cpu" else "VS PLAYER"
 	mode_label.text = mode_text
 
 
-func _unhandled_input(event: InputEvent) -> void:
+func _input(event: InputEvent) -> void:
 	if _transitioning:
 		return
 	if not event is InputEventKey or not event.pressed or event.echo:


### PR DESCRIPTION
## P0 Fix — Character Select Input (Third Attempt)

Two previous PRs (#116, #118) failed to fix keyboard input on the character select screen. This PR attacks **two root causes** simultaneously.

### Root Cause 1: \_unhandled_input\ never fires in built .exe
The scene tree has GUI nodes (Labels, ColorRects) that consume input events before \_unhandled_input\ gets called. **Fix:** switched to \_input\ which fires **first** in Godot's input pipeline, before any node processing. Also added \set_process_input(true)\ in \_ready()\ as a safeguard.

### Root Cause 2: CI export skips project import
Godot 4 headless export requires the project to be imported first so that scripts attach to scenes correctly. Without this step, the exported .exe may have detached scripts. **Fix:** added \godot --headless --import\ step before the export step in the CI workflow.

### Changes
- \games/ashfall/scripts/ui/character_select.gd\: \_unhandled_input\ → \_input\, added \set_process_input(true)\
- \.github/workflows/godot-release.yml\: added import step before export

### Testing
Tag a release after merge and verify keyboard input works in the built .exe.