### PR TITLE
fix: combat code fixes (#130, #132, #135)

### DIFF
--- a/.squad/agents/lando/history.md
+++ b/.squad/agents/lando/history.md
@@ -204,6 +204,15 @@
 - **Key Lesson:** When a previous fix for the same bug fails, don't iterate on the same approach — audit the entire pipeline and find what assumption was wrong. PR #116 assumed ui_* actions existed; the fix was to eliminate that assumption.
 - **PR:** #118 (squad/fix-charselect-v2), supersedes PR #116
 
+### 2026-03-11 — Combat Code Fixes (#130, #132, #135)
+
+- **#130:** Float precision in attack_state gravity. Fixed `int(fighter.gravity)/60` to `fighter.gravity/60.0`.
+- **#132:** Type guard in crouch_state before CollisionShape2D cast.
+- **#135:** take_damage chip call fixed from 1 arg to 3 `(chip, Vector2.ZERO, 0)`.
+- **Key Lesson:** Grep all callers when auditing function signatures.
+- **Key Lesson:** Float division consistency — use `/ 60.0` not `int() / 60`.
+
+
 
 ### 2026-03-09 — Sprint 1 Audit Results: Process & Standards
 

--- a/games/ashfall/scripts/fight_scene.gd
+++ b/games/ashfall/scripts/fight_scene.gd
@@ -66,7 +66,7 @@ func _on_hit_landed(attacker, target, move: Dictionary) -> void:
 		EventBus.hit_blocked.emit(attacker, target, move)
 		var chip: int = maxi(1, move.get("damage", 10) / 10)
 		if target.has_method("take_damage"):
-			target.take_damage(chip)
+			target.take_damage(chip, Vector2.ZERO, 0)
 		return
 
 	var base_damage: int = move.get("damage", 10)

--- a/games/ashfall/scripts/fighters/states/attack_state.gd
+++ b/games/ashfall/scripts/fighters/states/attack_state.gd
@@ -55,9 +55,8 @@ func physics_update() -> void:
 		return
 
 	# Gravity still applies (especially for air attacks)
-	# Frame-based integer math: gravity is per-second, divide by 60 with int()
 	if not fighter.is_on_floor():
-		fighter.velocity.y += int(fighter.gravity) / 60
+		fighter.velocity.y += fighter.gravity / 60.0
 	else:
 		fighter.velocity.y = 0
 

--- a/games/ashfall/scripts/fighters/states/crouch_state.gd
+++ b/games/ashfall/scripts/fighters/states/crouch_state.gd
@@ -13,7 +13,10 @@ func enter(args: Dictionary) -> void:
 		return
 	fighter.velocity.x = 0
 	# Shrink hurtbox to simulate ducking
-	var hurtbox_shape: CollisionShape2D = fighter.hurtbox.get_child(0) as CollisionShape2D
+	var node: Node = fighter.hurtbox.get_child(0)
+	if not (node is CollisionShape2D):
+		return
+	var hurtbox_shape: CollisionShape2D = node as CollisionShape2D
 	if hurtbox_shape:
 		_original_hurtbox_scale = hurtbox_shape.scale
 		hurtbox_shape.scale.y = fighter.crouch_hurtbox_scale
@@ -25,7 +28,10 @@ func exit() -> void:
 	if not fighter:
 		return
 	# Restore hurtbox
-	var hurtbox_shape: CollisionShape2D = fighter.hurtbox.get_child(0) as CollisionShape2D
+	var node: Node = fighter.hurtbox.get_child(0)
+	if not (node is CollisionShape2D):
+		return
+	var hurtbox_shape: CollisionShape2D = node as CollisionShape2D
 	if hurtbox_shape:
 		hurtbox_shape.scale = _original_hurtbox_scale
 		hurtbox_shape.position.y -= 10.0


### PR DESCRIPTION
Fixes #130, #132, #135.

## Changes
- **attack_state.gd (#130):** Replaced int(fighter.gravity) / 60 with fighter.gravity / 60.0 — eliminates float-to-int precision loss on air attack gravity.
- **crouch_state.gd (#132):** Added type guard before unsafe as CollisionShape2D cast in both enter() and exit().
- **fight_scene.gd (#135):** Fixed take_damage(chip) call to match 3-param signature: take_damage(chip, Vector2.ZERO, 0).

All changes follow GDSCRIPT-STANDARDS.md.