### PR TITLE
Add Discord webhook notifications for critical squad events

### DIFF
--- a/.github/workflows/squad-notify-ci-failure.yml
+++ b/.github/workflows/squad-notify-ci-failure.yml
@@ -1,0 +1,26 @@
+name: Squad Notify - CI Failure
+
+# Triggers when any workflow fails on main branch
+# Sends Discord notification for visibility
+
+on:
+  workflow_run:
+    workflows: ["*"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  notify-on-failure:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    uses: ./.github/workflows/squad-notify-discord.yml
+    with:
+      event_type: "CI Failure on main"
+      summary: "Workflow '${{ github.event.workflow_run.name }}' failed on main branch"
+      link: "${{ github.event.workflow_run.html_url }}"
+      color: "15158332"
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/squad-notify-discord.yml
+++ b/.github/workflows/squad-notify-discord.yml
@@ -1,0 +1,105 @@
+name: Squad Discord Notification
+
+# Reusable workflow for sending Discord webhook notifications
+# Rate-limited to 10 notifications per hour to prevent spam
+
+on:
+  workflow_call:
+    inputs:
+      event_type:
+        description: 'Event type (e.g., "CI Failure", "PR Merged")'
+        required: true
+        type: string
+      summary:
+        description: 'One-line summary of the event'
+        required: true
+        type: string
+      link:
+        description: 'URL to the relevant resource'
+        required: true
+        type: string
+      color:
+        description: 'Discord embed color (decimal, e.g., 15158332 for red)'
+        required: false
+        type: string
+        default: '5814783'
+    secrets:
+      DISCORD_WEBHOOK_URL:
+        required: true
+
+jobs:
+  send-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check rate limit
+        id: rate_check
+        run: |
+          RATE_FILE=".github/.discord-rate-limit"
+          MAX_PER_HOUR=10
+          CURRENT_TIME=$(date +%s)
+          HOUR_AGO=$((CURRENT_TIME - 3600))
+          
+          # Create rate file if it doesn't exist
+          if [ ! -f "$RATE_FILE" ]; then
+            echo "$CURRENT_TIME" > "$RATE_FILE"
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Count notifications in the last hour
+          COUNT=$(awk -v hour_ago="$HOUR_AGO" '$1 > hour_ago' "$RATE_FILE" | wc -l)
+          
+          if [ "$COUNT" -ge "$MAX_PER_HOUR" ]; then
+            echo "Rate limit exceeded: $COUNT notifications in the last hour"
+            echo "allowed=false" >> $GITHUB_OUTPUT
+          else
+            echo "$CURRENT_TIME" >> "$RATE_FILE"
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            
+            # Clean old entries (keep last 20 for efficiency)
+            tail -n 20 "$RATE_FILE" > "${RATE_FILE}.tmp"
+            mv "${RATE_FILE}.tmp" "$RATE_FILE"
+          fi
+
+      - name: Send Discord notification
+        if: steps.rate_check.outputs.allowed == 'true'
+        run: |
+          EVENT_TYPE="${{ inputs.event_type }}"
+          SUMMARY="${{ inputs.summary }}"
+          LINK="${{ inputs.link }}"
+          COLOR="${{ inputs.color }}"
+          
+          # Map event types to emojis (text-based for ASCII safety)
+          case "$EVENT_TYPE" in
+            *"CI Failure"*) EMOJI="[FAIL]" ;;
+            *"PR Merged"*) EMOJI="[MERGE]" ;;
+            *"Priority"*) EMOJI="[ALERT]" ;;
+            *"Ralph"*) EMOJI="[RALPH]" ;;
+            *) EMOJI="[INFO]" ;;
+          esac
+          
+          # Build Discord embed JSON
+          JSON_PAYLOAD=$(cat <<EOF
+          {
+            "embeds": [{
+              "title": "$EMOJI $EVENT_TYPE",
+              "description": "$SUMMARY",
+              "url": "$LINK",
+              "color": $COLOR,
+              "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            }]
+          }
+          EOF
+          )
+          
+          # Send to Discord webhook
+          curl -H "Content-Type: application/json" \
+               -d "$JSON_PAYLOAD" \
+               "${{ secrets.DISCORD_WEBHOOK_URL }}"
+
+      - name: Log rate limit skip
+        if: steps.rate_check.outputs.allowed == 'false'
+        run: |
+          echo "::warning::Discord notification skipped due to rate limit (max 10/hour)"

--- a/.github/workflows/squad-notify-pr-merged.yml
+++ b/.github/workflows/squad-notify-pr-merged.yml
@@ -1,0 +1,25 @@
+name: Squad Notify - PR Merged
+
+# Triggers when a PR is merged to main branch
+# Sends Discord notification for team awareness
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify-on-merge:
+    if: ${{ github.event.pull_request.merged == true }}
+    uses: ./.github/workflows/squad-notify-discord.yml
+    with:
+      event_type: "PR Merged to main"
+      summary: "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+      link: "${{ github.event.pull_request.html_url }}"
+      color: "5763719"
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/squad-notify-priority-issue.yml
+++ b/.github/workflows/squad-notify-priority-issue.yml
@@ -1,0 +1,26 @@
+name: Squad Notify - Priority Issue
+
+# Triggers when an issue is labeled priority:p0 or priority:critical
+# Sends Discord notification for immediate attention
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  notify-priority-issue:
+    if: >
+      github.event.label.name == 'priority:p0' ||
+      github.event.label.name == 'priority:critical'
+    uses: ./.github/workflows/squad-notify-discord.yml
+    with:
+      event_type: "Priority Issue Labeled"
+      summary: "Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }} [Label: ${{ github.event.label.name }}]"
+      link: "${{ github.event.issue.html_url }}"
+      color: "16711680"
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/squad-notify-ralph-heartbeat.yml
+++ b/.github/workflows/squad-notify-ralph-heartbeat.yml
@@ -1,0 +1,66 @@
+name: Squad Notify - Ralph Heartbeat
+
+# Scheduled check of Ralph's heartbeat status
+# Sends notification when Ralph completes a round (every 30 minutes during active hours)
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'  # Every 30 minutes
+  workflow_dispatch:  # Manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  check-and-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Ralph heartbeat
+        id: heartbeat
+        run: |
+          HEARTBEAT_FILE="tools/.ralph-heartbeat.json"
+          
+          if [ ! -f "$HEARTBEAT_FILE" ]; then
+            echo "No heartbeat file found"
+            echo "should_notify=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Parse heartbeat data
+          STATUS=$(jq -r '.status' "$HEARTBEAT_FILE")
+          ROUND=$(jq -r '.round' "$HEARTBEAT_FILE")
+          MODE=$(jq -r '.mode' "$HEARTBEAT_FILE")
+          FAILURES=$(jq -r '.consecutiveFailures' "$HEARTBEAT_FILE")
+          
+          # Check if round number changed since last notification
+          LAST_ROUND_FILE=".github/.ralph-last-notified-round"
+          LAST_ROUND=0
+          
+          if [ -f "$LAST_ROUND_FILE" ]; then
+            LAST_ROUND=$(cat "$LAST_ROUND_FILE")
+          fi
+          
+          # Only notify if round number increased
+          if [ "$ROUND" -gt "$LAST_ROUND" ]; then
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+            echo "status=$STATUS" >> $GITHUB_OUTPUT
+            echo "round=$ROUND" >> $GITHUB_OUTPUT
+            echo "mode=$MODE" >> $GITHUB_OUTPUT
+            echo "failures=$FAILURES" >> $GITHUB_OUTPUT
+            echo "$ROUND" > "$LAST_ROUND_FILE"
+          else
+            echo "should_notify=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify round completion
+        if: steps.heartbeat.outputs.should_notify == 'true'
+        uses: ./.github/workflows/squad-notify-discord.yml
+        with:
+          event_type: "Ralph Round Completed"
+          summary: "Ralph completed round ${{ steps.heartbeat.outputs.round }} in ${{ steps.heartbeat.outputs.mode }} mode (Status: ${{ steps.heartbeat.outputs.status }}, Failures: ${{ steps.heartbeat.outputs.failures }})"
+          link: "${{ github.server_url }}/${{ github.repository }}/actions/workflows/squad-notify-ralph-heartbeat.yml"
+          color: "3066993"
+        secrets:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/tools/README.md
+++ b/tools/README.md
@@ -159,5 +159,77 @@ The following tools were built for previous projects (Ashfall/Godot) and are arc
 
 ---
 
+## Discord Webhook Notifications
+
+The squad can now send Discord notifications for critical events. Notifications are rate-limited to 10 per hour to prevent spam.
+
+### Setup
+
+1. **Create a Discord webhook:**
+   - In Discord: Server Settings → Integrations → Webhooks → New Webhook
+   - Copy the webhook URL
+
+2. **Configure GitHub secret:**
+   ```bash
+   # Add the webhook URL as a repository secret
+   gh secret set DISCORD_WEBHOOK_URL
+   # Paste webhook URL when prompted
+   ```
+
+3. **Verify workflows:**
+   - Go to Actions tab in GitHub
+   - Workflows should be enabled automatically
+
+### What Gets Notified
+
+| Event | Trigger | Workflow |
+|-------|---------|----------|
+| CI Failure on main | Any workflow fails on main branch | `squad-notify-ci-failure.yml` |
+| PR Merged | Pull request merged to main | `squad-notify-pr-merged.yml` |
+| Priority Issue | Issue labeled `priority:p0` or `priority:critical` | `squad-notify-priority-issue.yml` |
+| Ralph Round | Ralph completes a round (checked every 30 min) | `squad-notify-ralph-heartbeat.yml` |
+
+### Manual Notifications from Scripts
+
+Use the helper script from PowerShell:
+
+```powershell
+# Send a notification from ralph-watch or other automation
+.\tools\send-discord-notification.ps1 `
+  -EventType "Ralph Round" `
+  -Summary "Round 42 completed in night mode (3 issues closed)" `
+  -Link "https://github.com/jperezdelreal/FirstFrameStudios/actions" `
+  -Color 3066993
+
+# Set webhook URL via environment variable
+$env:DISCORD_WEBHOOK_URL = "your-webhook-url"
+.\tools\send-discord-notification.ps1 -EventType "Test" -Summary "Hello!" -Link "https://example.com"
+```
+
+Color codes (decimal):
+- Red (failures/alerts): `15158332`
+- Green (success): `5763719`
+- Blue (info): `3066993`
+- Gray (neutral): `5814783`
+
+### Rate Limiting
+
+- Max 10 notifications per hour (enforced in workflows and script)
+- Older notifications are tracked in `.github/.discord-rate-limit` (workflows) or `tools/.discord-rate-limit` (scripts)
+- Rate limit exceeded = notification silently skipped with warning log
+
+### Troubleshooting
+
+**No notifications arriving:**
+1. Check webhook URL is configured: `gh secret list` (should show `DISCORD_WEBHOOK_URL`)
+2. Check workflow runs in Actions tab for errors
+3. Verify Discord webhook is active in server settings
+
+**Too many notifications:**
+- Rate limit prevents spam (max 10/hour)
+- Adjust triggers in workflow files if needed
+
+---
+
 **Maintained by:** Jango (Tool Engineer)
-**Last updated:** 2026-03-11
+**Last updated:** 2026-03-12

--- a/tools/send-discord-notification.ps1
+++ b/tools/send-discord-notification.ps1
@@ -1,0 +1,93 @@
+# Send Discord Notification Helper Script
+# First Frame Studios -- Tool for ralph-watch.ps1 and other automation
+#
+# Sends a notification to Discord webhook with rate limiting
+# ASCII-safe (no emojis) for PowerShell compatibility
+#
+# Usage:
+#   .\tools\send-discord-notification.ps1 -EventType "Ralph Round" -Summary "Round 42 completed" -Link "https://..."
+#   .\tools\send-discord-notification.ps1 -EventType "CI Failure" -Summary "Build failed" -Link "..." -Color 15158332
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$EventType,
+    
+    [Parameter(Mandatory=$true)]
+    [string]$Summary,
+    
+    [Parameter(Mandatory=$true)]
+    [string]$Link,
+    
+    [int]$Color = 5814783,  # Default blue color
+    
+    [string]$WebhookUrl = $env:DISCORD_WEBHOOK_URL,
+    
+    [int]$MaxPerHour = 10
+)
+
+# Check if webhook URL is configured
+if (-not $WebhookUrl) {
+    Write-Warning "DISCORD_WEBHOOK_URL not configured. Set environment variable or pass -WebhookUrl parameter."
+    exit 1
+}
+
+# Rate limiting check
+$rateLimitFile = Join-Path $PSScriptRoot ".discord-rate-limit"
+$currentTime = [int][double]::Parse((Get-Date -UFormat %s))
+$hourAgo = $currentTime - 3600
+
+# Create rate limit file if it doesn't exist
+if (-not (Test-Path $rateLimitFile)) {
+    $currentTime | Out-File -FilePath $rateLimitFile -Encoding ASCII
+}
+else {
+    # Read existing timestamps and filter to last hour
+    $timestamps = Get-Content $rateLimitFile | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ }
+    $recentTimestamps = $timestamps | Where-Object { $_ -gt $hourAgo }
+    
+    # Check rate limit
+    if ($recentTimestamps.Count -ge $MaxPerHour) {
+        Write-Warning "Rate limit exceeded: $($recentTimestamps.Count) notifications in the last hour (max $MaxPerHour)"
+        exit 0  # Soft exit - not an error, just skipped
+    }
+    
+    # Append current timestamp
+    $currentTime | Out-File -FilePath $rateLimitFile -Append -Encoding ASCII
+    
+    # Clean up old entries (keep last 20 for efficiency)
+    $allTimestamps = Get-Content $rateLimitFile | Where-Object { $_ -match '^\d+$' } | Select-Object -Last 20
+    $allTimestamps | Out-File -FilePath $rateLimitFile -Encoding ASCII
+}
+
+# Map event types to text prefixes (ASCII-safe, no emojis)
+$emoji = switch -Wildcard ($EventType) {
+    "*CI Failure*" { "[FAIL]" }
+    "*PR Merged*" { "[MERGE]" }
+    "*Priority*" { "[ALERT]" }
+    "*Ralph*" { "[RALPH]" }
+    default { "[INFO]" }
+}
+
+# Build Discord embed JSON
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$jsonPayload = @{
+    embeds = @(
+        @{
+            title = "$emoji $EventType"
+            description = $Summary
+            url = $Link
+            color = $Color
+            timestamp = $timestamp
+        }
+    )
+} | ConvertTo-Json -Depth 3
+
+# Send to Discord webhook
+try {
+    $response = Invoke-RestMethod -Uri $WebhookUrl -Method Post -Body $jsonPayload -ContentType "application/json"
+    Write-Host "[OK] Discord notification sent: $EventType"
+}
+catch {
+    Write-Warning "Failed to send Discord notification: $_"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Implements webhook notification system for critical squad events as specified in #163.

## What Changed

### GitHub Actions Workflows
- **squad-notify-discord.yml** - Reusable workflow for sending Discord notifications with rate limiting
- **squad-notify-ci-failure.yml** - Notifies on CI failures on main branch
- **squad-notify-pr-merged.yml** - Notifies when PRs are merged to main
- **squad-notify-priority-issue.yml** - Notifies on priority:p0 or priority:critical labels
- **squad-notify-ralph-heartbeat.yml** - Notifies on Ralph round completion (checked every 30 min)

### PowerShell Helper Script
- **tools/send-discord-notification.ps1** - Helper for ralph-watch and other automation to send notifications
- ASCII-safe (no emojis), rate-limited, uses DISCORD_WEBHOOK_URL env var

### Documentation
- Updated **tools/README.md** with webhook setup instructions, event table, manual usage examples

## Features
- Rate limiting: max 10 notifications/hour (prevents spam)
- All notifications include: event type, link, 1-line summary
- Color-coded embeds (red=failures, green=merges, blue=info)
- Uses GitHub secret DISCORD_WEBHOOK_URL (no hardcoded URLs)

## Setup Required
1. Create Discord webhook in server settings
2. Add webhook URL to GitHub repository secrets: gh secret set DISCORD_WEBHOOK_URL
3. Workflows will activate automatically

## Testing
- Workflows are configured but will only send when DISCORD_WEBHOOK_URL secret is set
- Rate limiting prevents spam during testing
- All workflows follow GitHub Actions best practices

Closes #163