### PR TITLE
fix: auto-create ceremony labels before issue creation (hotfix)

### DIFF
--- a/tools/ralph-watch.ps1
+++ b/tools/ralph-watch.ps1
@@ -724,6 +724,16 @@ function Check-ProjectLifecycle {
                 $nextSprint = $sprint + 1
                 $body = "Sprint Planning ceremony triggered. Lead: read the design doc at ``$designDoc``, compare with open issues, create Sprint $nextSprint issues. See .squad/ceremonies.md for the full process."
                 $labels = "squad,squad:$leadName,ceremony:sprint-planning,go:ready"
+
+                # Ensure required labels exist before creating ceremony issue (gh label create is idempotent)
+                $requiredLabels = @(
+                    @{ name = "ceremony:sprint-planning"; color = "0E8A16"; description = "Sprint Planning ceremony trigger" },
+                    @{ name = "go:ready"; color = "0E8A16"; description = "Ready for implementation" }
+                )
+                foreach ($lbl in $requiredLabels) {
+                    gh label create $lbl.name --repo $ghRepo --color $lbl.color --description $lbl.description 2>$null
+                }
+
                 Write-Host "   [lifecycle] $repoName -- creating Sprint Planning ceremony issue" -ForegroundColor Cyan
                 if (-not $DryRun) {
                     gh issue create -R $ghRepo --title "[CEREMONY] Sprint Planning" --body $body --label $labels 2>$null
@@ -762,6 +772,16 @@ function Check-ProjectLifecycle {
                         $nextSprint = $sprint + 1
                         $body = "Sprint Planning ceremony triggered. Lead: read the design doc at ``$designDoc``, compare with open issues, create Sprint $nextSprint issues. See .squad/ceremonies.md for the full process."
                         $labels = "squad,squad:$leadName,ceremony:sprint-planning,go:ready"
+
+                        # Ensure required labels exist before creating ceremony issue (gh label create is idempotent)
+                        $requiredLabels = @(
+                            @{ name = "ceremony:sprint-planning"; color = "0E8A16"; description = "Sprint Planning ceremony trigger" },
+                            @{ name = "go:ready"; color = "0E8A16"; description = "Ready for implementation" }
+                        )
+                        foreach ($lbl in $requiredLabels) {
+                            gh label create $lbl.name --repo $ghRepo --color $lbl.color --description $lbl.description 2>$null
+                        }
+
                         Write-Host "   [lifecycle] $repoName -- creating Sprint Planning ceremony issue" -ForegroundColor Cyan
                         gh issue create -R $ghRepo --title "[CEREMONY] Sprint Planning" --body $body --label $labels 2>$null
                     }


### PR DESCRIPTION
## Hotfix: Silent failure in Check-ProjectLifecycle

**Problem:** When \Check-ProjectLifecycle\ tries to create a \[CEREMONY] Sprint Planning\ issue, it fails silently if the required labels (\ceremony:sprint-planning\, \go:ready\) don't exist in the target repo. The \gh issue create\ call's stderr is redirected to \\\, so no error is surfaced and no issue is created.

**Fix:** Added \gh label create\ calls (idempotent -- harmless if label already exists) before both \gh issue create\ call sites in \Check-ProjectLifecycle\:
1. **Sprint-planning phase trigger** (line ~728) -- when a ceremony issue needs to be created for a repo already in sprint-planning phase
2. **Sprint transition** (line ~776) -- when all sprint issues close and the function transitions the repo to sprint-planning

Labels auto-created:
- \ceremony:sprint-planning\ (color: \