### PR TITLE
feat: harden ralph-watch for 24h unattended operation (P1-08)

### DIFF
--- a/.github/workflows/squad-notify-ralph-heartbeat.yml
+++ b/.github/workflows/squad-notify-ralph-heartbeat.yml
@@ -1,15 +1,17 @@
 name: Squad Notify - Ralph Heartbeat
 
-# Scheduled check of Ralph's heartbeat status
-# Sends notification when Ralph completes a round (every 4 hours)
+# Hardened heartbeat monitor (P1-08)
+# Checks: round progress, staleness detection, failure escalation
+# Runs every hour (was every 4h) for faster failure detection
 
 on:
   schedule:
-    - cron: '0 */4 * * *'  # Every 4 hours
+    - cron: '0 * * * *'  # Every hour
   workflow_dispatch:  # Manual trigger
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   check-heartbeat:
@@ -18,8 +20,9 @@ jobs:
       should_notify: ${{ steps.heartbeat.outputs.should_notify }}
       status: ${{ steps.heartbeat.outputs.status }}
       round: ${{ steps.heartbeat.outputs.round }}
-      mode: ${{ steps.heartbeat.outputs.mode }}
       failures: ${{ steps.heartbeat.outputs.failures }}
+      alert_level: ${{ steps.heartbeat.outputs.alert_level }}
+      message: ${{ steps.heartbeat.outputs.message }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,47 +30,171 @@ jobs:
         id: heartbeat
         run: |
           HEARTBEAT_FILE="tools/.ralph-heartbeat.json"
-          
+
           if [ ! -f "$HEARTBEAT_FILE" ]; then
             echo "No heartbeat file found"
             echo "should_notify=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # Parse heartbeat data
-          STATUS=$(jq -r '.status' "$HEARTBEAT_FILE")
-          ROUND=$(jq -r '.round' "$HEARTBEAT_FILE")
-          MODE=$(jq -r '.mode' "$HEARTBEAT_FILE")
-          FAILURES=$(jq -r '.consecutiveFailures' "$HEARTBEAT_FILE")
-          
-          # Check if round number changed since last notification
-          LAST_ROUND_FILE=".github/.ralph-last-notified-round"
-          LAST_ROUND=0
-          
-          if [ -f "$LAST_ROUND_FILE" ]; then
-            LAST_ROUND=$(cat "$LAST_ROUND_FILE")
+          STATUS=$(jq -r '.status // "unknown"' "$HEARTBEAT_FILE")
+          ROUND=$(jq -r '.round // 0' "$HEARTBEAT_FILE")
+          FAILURES=$(jq -r '.consecutiveFailures // 0' "$HEARTBEAT_FILE")
+          TIMESTAMP=$(jq -r '.timestamp // ""' "$HEARTBEAT_FILE")
+          LAST_STATUS=$(jq -r '.lastStatus // ""' "$HEARTBEAT_FILE")
+
+          # Staleness detection: alert if heartbeat is older than 30 minutes
+          STALE="false"
+          STALE_MINUTES=0
+          if [ -n "$TIMESTAMP" ] && [ "$TIMESTAMP" != "null" ]; then
+            HEARTBEAT_EPOCH=$(date -d "$TIMESTAMP" +%s 2>/dev/null || echo 0)
+            NOW_EPOCH=$(date +%s)
+            if [ "$HEARTBEAT_EPOCH" -gt 0 ]; then
+              DIFF=$(( NOW_EPOCH - HEARTBEAT_EPOCH ))
+              STALE_MINUTES=$(( DIFF / 60 ))
+              if [ "$DIFF" -gt 1800 ] && [ "$STATUS" = "running" ]; then
+                STALE="true"
+              fi
+              if [ "$DIFF" -gt 3600 ] && [ "$STATUS" != "stopped" ]; then
+                STALE="true"
+              fi
+            fi
           fi
-          
-          # Only notify if round number increased
-          if [ "$ROUND" -gt "$LAST_ROUND" ]; then
+
+          # Determine alert level
+          ALERT_LEVEL="info"
+          MESSAGE=""
+
+          if [ "$STALE" = "true" ]; then
+            ALERT_LEVEL="critical"
+            MESSAGE="⚠️ STALE HEARTBEAT: Last update ${STALE_MINUTES}m ago (status: $STATUS). Ralph may be hung or crashed."
             echo "should_notify=true" >> $GITHUB_OUTPUT
-            echo "status=$STATUS" >> $GITHUB_OUTPUT
-            echo "round=$ROUND" >> $GITHUB_OUTPUT
-            echo "mode=$MODE" >> $GITHUB_OUTPUT
-            echo "failures=$FAILURES" >> $GITHUB_OUTPUT
-            echo "$ROUND" > "$LAST_ROUND_FILE"
+          elif [ "$FAILURES" -ge 5 ]; then
+            ALERT_LEVEL="critical"
+            MESSAGE="🔴 $FAILURES consecutive failures. Circuit breaker may trip soon."
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+          elif [ "$FAILURES" -ge 3 ]; then
+            ALERT_LEVEL="warning"
+            MESSAGE="🟡 $FAILURES consecutive failures. Exponential backoff active."
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+          elif [ "$STATUS" = "stopped" ]; then
+            # Only notify once when stopped
+            LAST_ROUND_FILE=".github/.ralph-last-notified-round"
+            LAST_ROUND=0
+            if [ -f "$LAST_ROUND_FILE" ]; then
+              LAST_ROUND=$(cat "$LAST_ROUND_FILE")
+            fi
+            if [ "$ROUND" != "$LAST_ROUND" ]; then
+              ALERT_LEVEL="warning"
+              MESSAGE="⏹️ Ralph stopped after round $ROUND."
+              echo "should_notify=true" >> $GITHUB_OUTPUT
+              echo "$ROUND" > "$LAST_ROUND_FILE"
+            else
+              echo "should_notify=false" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "should_notify=false" >> $GITHUB_OUTPUT
+            # Normal operation — notify on new round (every 4 checks = every 4h)
+            LAST_ROUND_FILE=".github/.ralph-last-notified-round"
+            LAST_ROUND=0
+            if [ -f "$LAST_ROUND_FILE" ]; then
+              LAST_ROUND=$(cat "$LAST_ROUND_FILE")
+            fi
+            if [ "$ROUND" -gt "$LAST_ROUND" ]; then
+              MESSAGE="✅ Round $ROUND completed (status: $LAST_STATUS, failures: $FAILURES)"
+              echo "should_notify=true" >> $GITHUB_OUTPUT
+              echo "$ROUND" > "$LAST_ROUND_FILE"
+            else
+              echo "should_notify=false" >> $GITHUB_OUTPUT
+            fi
           fi
+
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+          echo "round=$ROUND" >> $GITHUB_OUTPUT
+          echo "failures=$FAILURES" >> $GITHUB_OUTPUT
+          echo "alert_level=$ALERT_LEVEL" >> $GITHUB_OUTPUT
+          echo "message=$MESSAGE" >> $GITHUB_OUTPUT
 
   notify:
     needs: check-heartbeat
     if: needs.check-heartbeat.outputs.should_notify == 'true'
     uses: ./.github/workflows/squad-notify-discord.yml
     with:
-      event_type: "Ralph Round Completed"
-      summary: "Ralph completed round ${{ needs.check-heartbeat.outputs.round }} in ${{ needs.check-heartbeat.outputs.mode }} mode (Status: ${{ needs.check-heartbeat.outputs.status }}, Failures: ${{ needs.check-heartbeat.outputs.failures }})"
+      event_type: "Ralph Heartbeat"
+      summary: "${{ needs.check-heartbeat.outputs.message }}"
       link: "${{ github.server_url }}/${{ github.repository }}/actions/workflows/squad-notify-ralph-heartbeat.yml"
-      color: "3066993"
+      color: ${{ needs.check-heartbeat.outputs.alert_level == 'critical' && '15158332' || needs.check-heartbeat.outputs.alert_level == 'warning' && '16776960' || '3066993' }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+  create-issue-on-critical:
+    needs: check-heartbeat
+    if: needs.check-heartbeat.outputs.alert_level == 'critical'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create alert issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check for existing open alert issue to avoid duplicates
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'ralph-alert',
+              state: 'open',
+              per_page: 1
+            });
+
+            if (existing.length > 0) {
+              core.info('Alert issue already exists: #' + existing[0].number);
+              // Add comment instead
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body: `${{ needs.check-heartbeat.outputs.message }}\n\nRound: ${{ needs.check-heartbeat.outputs.round }} | Failures: ${{ needs.check-heartbeat.outputs.failures }} | Status: ${{ needs.check-heartbeat.outputs.status }}`
+              });
+              return;
+            }
+
+            // Ensure label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ralph-alert',
+                color: 'B60205',
+                description: 'Ralph autonomous loop critical alert'
+              });
+            } catch (e) { /* label may already exist */ }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🚨 Ralph Alert — ' + '${{ needs.check-heartbeat.outputs.message }}'.substring(0, 80),
+              body: [
+                '## Ralph Health Alert',
+                '',
+                '${{ needs.check-heartbeat.outputs.message }}',
+                '',
+                '| Metric | Value |',
+                '|--------|-------|',
+                '| Round | ${{ needs.check-heartbeat.outputs.round }} |',
+                '| Status | ${{ needs.check-heartbeat.outputs.status }} |',
+                '| Consecutive Failures | ${{ needs.check-heartbeat.outputs.failures }} |',
+                '',
+                '**Action needed:** Check if ralph-watch is running on the host machine.',
+                '',
+                '```powershell',
+                '# Check heartbeat',
+                'Get-Content tools\\.ralph-heartbeat.json | ConvertFrom-Json',
+                '',
+                '# Restart ralph',
+                '.\\tools\\ralph-watch.ps1',
+                '```',
+                '',
+                '---',
+                '_Auto-created by squad-notify-ralph-heartbeat workflow_'
+              ].join('\n'),
+              labels: ['ralph-alert', 'priority:p0']
+            });

--- a/tools/ralph-watch.ps1
+++ b/tools/ralph-watch.ps1
@@ -1,22 +1,24 @@
-﻿# Ralph Watch v4 -- Simplified Autonomous Squad Agent Loop
-# First Frame Studios -- Tamir-style rewrite
+﻿# Ralph Watch v5 -- Hardened for 24h Unattended Operation
+# First Frame Studios -- Tank hardening (P1-08)
 #
-# v4: Multi-repo via prompt scope, not script complexity.
-# Squad agent handles parallelism and issue scheduling internally.
-# Dropped: night/day mode, issue pre-fetching, activity monitors, PR dedup tracking.
-# Kept: lock file, JSONL logging, heartbeat, alerts, session timeout, circuit breaker,
+# v5: Hardened from v4 for 24h continuous operation without human intervention.
+# Added: session timeout, exponential backoff, improved log rotation,
+#        stale lock detection, pre-round health checks, enhanced heartbeat.
+# Kept: lock file, JSONL logging, heartbeat, alerts, circuit breaker,
 #       upstream sync, project lifecycle, scheduler integration.
 #
 # Usage:
-#   .\tools\ralph-watch.ps1                        # default: 5min interval
-#   .\tools\ralph-watch.ps1 -DryRun                # show what would happen
-#   .\tools\ralph-watch.ps1 -MaxRounds 3           # stop after 3 rounds
-#   .\tools\ralph-watch.ps1 -IntervalMinutes 10    # custom interval
+#   .\tools\ralph-watch.ps1                            # default: 5min interval
+#   .\tools\ralph-watch.ps1 -DryRun                    # show what would happen
+#   .\tools\ralph-watch.ps1 -MaxRounds 3               # stop after 3 rounds
+#   .\tools\ralph-watch.ps1 -IntervalMinutes 10        # custom interval
+#   .\tools\ralph-watch.ps1 -SessionTimeoutMinutes 45  # longer session limit
 
 param(
     [int]$IntervalMinutes = 5,
     [switch]$DryRun,
-    [int]$MaxRounds = 0
+    [int]$MaxRounds = 0,
+    [int]$SessionTimeoutMinutes = 30
 )
 
 # --- UTF-8 console fix for Windows PowerShell ---
@@ -42,6 +44,11 @@ $circuitBreakerThreshold = 10
 $circuitBreakerTrips = 0
 $maxCircuitBreakerTrips = 3
 
+# Backoff settings (exponential on consecutive failures)
+$baseInterval = $IntervalMinutes
+$maxBackoffMinutes = 60
+$staleLockThresholdHours = 2
+
 # Downstream repo names (siblings of hub)
 $downstreamRepoNames = @("ComeRosquillas", "flora", "ffs-squad-monitor")
 
@@ -58,15 +65,26 @@ $squadUserDir = Join-Path $env:USERPROFILE ".squad"
 if (-not (Test-Path $squadUserDir)) { New-Item -ItemType Directory -Path $squadUserDir -Force | Out-Null }
 if (-not (Test-Path $logsDir)) { New-Item -ItemType Directory -Path $logsDir -Force | Out-Null }
 
-# --- Single-instance guard ---
+# --- Single-instance guard (with stale lock detection) ---
 if (Test-Path $lockFile) {
     $lockContent = Get-Content $lockFile -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json -ErrorAction SilentlyContinue
     if ($lockContent -and $lockContent.pid) {
         $existing = Get-Process -Id $lockContent.pid -ErrorAction SilentlyContinue
         if ($existing) {
-            Write-Host "ERROR: Ralph watch is already running (PID $($lockContent.pid), started $($lockContent.started))" -ForegroundColor Red
-            Write-Host "Kill it first: Stop-Process -Id $($lockContent.pid) -Force" -ForegroundColor Yellow
-            exit 1
+            # Check if lock is stale by age
+            $lockAge = $null
+            if ($lockContent.started) {
+                try { $lockAge = (Get-Date) - [datetime]$lockContent.started } catch {}
+            }
+            if ($lockAge -and $lockAge.TotalHours -gt $staleLockThresholdHours) {
+                Write-Host "WARNING: Stale lock detected (PID $($lockContent.pid), age $([math]::Round($lockAge.TotalHours, 1))h). Killing stale process." -ForegroundColor Yellow
+                Stop-Process -Id $lockContent.pid -Force -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 2
+            } else {
+                Write-Host "ERROR: Ralph watch is already running (PID $($lockContent.pid), started $($lockContent.started))" -ForegroundColor Red
+                Write-Host "Kill it first: Stop-Process -Id $($lockContent.pid) -Force" -ForegroundColor Yellow
+                exit 1
+            }
         }
     }
     Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
@@ -161,10 +179,13 @@ function Write-RalphLog {
     }
     ($entry | ConvertTo-Json -Compress) | Add-Content -Path $logPath -Encoding utf8
 
-    # Log rotation: if file exceeds 1MB, rotate to .1
+    # Log rotation: keep 3 files (rotate .2 -> .3, .1 -> .2, current -> .1)
     if ((Test-Path $logPath) -and ((Get-Item $logPath).Length -gt $maxLogBytes)) {
-        $rotated = $logPath -replace '\.jsonl$', '.1.jsonl'
-        Move-Item $logPath $rotated -Force -ErrorAction SilentlyContinue
+        for ($i = 3; $i -ge 1; $i--) {
+            $src = if ($i -eq 1) { $logPath } else { $logPath -replace '\.jsonl$', ".$($i-1).jsonl" }
+            $dst = $logPath -replace '\.jsonl$', ".$i.jsonl"
+            if (Test-Path $src) { Move-Item $src $dst -Force -ErrorAction SilentlyContinue }
+        }
     }
 }
 
@@ -251,6 +272,108 @@ function Get-RepoName {
     $resolved = Resolve-Path $RepoPath -ErrorAction SilentlyContinue
     if ($resolved) { return (Split-Path $resolved.Path -Leaf) }
     return (Split-Path $RepoPath -Leaf)
+}
+
+function Get-BackoffInterval {
+    param([int]$Failures, [int]$BaseMinutes, [int]$MaxMinutes)
+    if ($Failures -le 0) { return $BaseMinutes }
+    $backoff = $BaseMinutes * [math]::Pow(2, [math]::Min($Failures, 6))
+    return [math]::Min([int]$backoff, $MaxMinutes)
+}
+
+function Invoke-CopilotWithTimeout {
+    param(
+        [string]$Prompt,
+        [int]$TimeoutMinutes
+    )
+    $timeoutSec = $TimeoutMinutes * 60
+    $tmpOut = [System.IO.Path]::GetTempFileName()
+    $tmpErr = [System.IO.Path]::GetTempFileName()
+
+    try {
+        Write-Host "   [copilot] Running session (timeout: ${TimeoutMinutes}m)..." -ForegroundColor Cyan
+        Write-Host "   ────────────────────────────────────────" -ForegroundColor DarkGray
+
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = "copilot"
+        $psi.Arguments = "--agent squad --yolo -p `"$($Prompt -replace '"', '\"')`""
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+
+        # Read output async to prevent deadlocks
+        $outTask = $proc.StandardOutput.ReadToEndAsync()
+        $errTask = $proc.StandardError.ReadToEndAsync()
+
+        $exited = $proc.WaitForExit($timeoutSec * 1000)
+
+        if (-not $exited) {
+            Write-Host "   [TIMEOUT] Session exceeded ${TimeoutMinutes}m limit. Killing process." -ForegroundColor Red
+            try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {}
+            $proc.WaitForExit(5000)
+            $output = if ($outTask.IsCompleted) { $outTask.Result } else { "[TIMEOUT] Partial output unavailable" }
+            Write-Host "   ────────────────────────────────────────" -ForegroundColor DarkGray
+            return @{ ExitCode = 124; Output = $output; TimedOut = $true }
+        }
+
+        $output = $outTask.Result
+        $stderr = $errTask.Result
+        $exitCode = $proc.ExitCode
+
+        if ($output) {
+            $output -split "`n" | ForEach-Object { Write-Host "   $_" -ForegroundColor DarkGray }
+        }
+        Write-Host "   ────────────────────────────────────────" -ForegroundColor DarkGray
+
+        return @{ ExitCode = $exitCode; Output = $output; TimedOut = $false }
+    } catch {
+        Write-Host "   [ERROR] Failed to start copilot: $_" -ForegroundColor Red
+        return @{ ExitCode = -1; Output = ""; TimedOut = $false }
+    } finally {
+        Remove-Item $tmpOut -Force -ErrorAction SilentlyContinue
+        Remove-Item $tmpErr -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-SystemHealth {
+    $healthy = $true
+
+    # Check copilot CLI is available
+    if (-not (Get-Command copilot -ErrorAction SilentlyContinue)) {
+        Write-Host "   [health] FAIL: 'copilot' CLI not in PATH" -ForegroundColor Red
+        $healthy = $false
+    }
+
+    # Check gh CLI is available
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Host "   [health] WARN: 'gh' CLI not in PATH" -ForegroundColor Yellow
+    }
+
+    # Check git is available
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Host "   [health] FAIL: 'git' not in PATH" -ForegroundColor Red
+        $healthy = $false
+    }
+
+    # Check disk space (warn if < 1GB free on repo drive)
+    try {
+        $drive = (Get-Item $script:repoRoot).PSDrive
+        $freeGB = [math]::Round($drive.Free / 1GB, 1)
+        if ($freeGB -lt 1) {
+            Write-Host "   [health] WARN: Low disk space ($freeGB GB free)" -ForegroundColor Yellow
+        }
+    } catch {}
+
+    # Clean up old temp files from previous sessions
+    $tempPattern = Join-Path $env:TEMP "ralph-copilot-*"
+    Get-ChildItem $tempPattern -ErrorAction SilentlyContinue | Where-Object {
+        $_.LastWriteTime -lt (Get-Date).AddHours(-2)
+    } | Remove-Item -Force -ErrorAction SilentlyContinue
+
+    return $healthy
 }
 
 function Test-HasSquadRoster {
@@ -539,8 +662,9 @@ foreach ($path in $existingDownstream) {
 }
 
 Write-Host ""
-Write-Host "[ralph] Ralph Watch v4 - First Frame Studios (Simplified)" -ForegroundColor Cyan
-Write-Host "   Interval:    $IntervalMinutes minutes" -ForegroundColor Gray
+Write-Host "[ralph] Ralph Watch v5 - Hardened for 24h Operation" -ForegroundColor Cyan
+Write-Host "   Interval:    $IntervalMinutes minutes (backoff up to $maxBackoffMinutes min on failures)" -ForegroundColor Gray
+Write-Host "   Timeout:     $SessionTimeoutMinutes minutes per session" -ForegroundColor Gray
 Write-Host "   Hub:         $repoRoot" -ForegroundColor Gray
 Write-Host "   Downstream:  $($existingDownstream.Count) repos found" -ForegroundColor Gray
 Write-Host "   Heartbeat:   $heartbeatFile" -ForegroundColor Gray
@@ -562,6 +686,20 @@ while ($true) {
     $timestamp = $roundStart.ToString('yyyy-MM-ddTHH:mm:ss')
 
     Write-Host "[$timestamp] [>>] Round $round starting..." -ForegroundColor Green
+
+    # Pre-round health check
+    if (-not (Test-SystemHealth)) {
+        Write-Host "   [health] Pre-round check failed. Skipping round." -ForegroundColor Red
+        $consecutiveFailures++
+        Write-RalphLog -Round $round -Status "HEALTH_FAIL" -ExitCode -2 -DurationSeconds 0 -Phase "health-check"
+        Update-Heartbeat -Status "idle" -Round $round -Extra @{
+            lastStatus = "HEALTH_FAIL"
+        }
+        if ($consecutiveFailures -ge $alertThreshold) {
+            Write-FailureAlert -Round $round -Failures $consecutiveFailures -ExitCode -2 -ErrorMessage "Pre-round health check failed"
+        }
+    } else {
+
     Update-Heartbeat -Status "running" -Round $round
 
     try {
@@ -582,19 +720,19 @@ while ($true) {
         # Step 4: Check project lifecycle
         Check-ProjectLifecycle -RepoNames $allRepoNames
 
-        # Step 5: Copilot session
+        # Step 5: Copilot session (with timeout)
         $exitCode = 0
         $copilotOutput = ""
+        $timedOut = $false
 
         if ($DryRun) {
-            Write-Host "   [DRY RUN] Would run: copilot --agent squad --yolo -p <prompt>" -ForegroundColor Yellow
+            Write-Host "   [DRY RUN] Would run: copilot --agent squad --yolo -p <prompt> (timeout: ${SessionTimeoutMinutes}m)" -ForegroundColor Yellow
             $copilotOutput = "[DRY RUN] No output captured"
         } else {
-            Write-Host "   [copilot] Running session (blocking, Tamir-style)..." -ForegroundColor Cyan
-            Write-Host "   ────────────────────────────────────────" -ForegroundColor DarkGray
-            $copilotOutput = copilot --agent squad --yolo -p $prompt 2>&1 | Tee-Object -Variable _teeBuffer | ForEach-Object { Write-Host "   $_" -ForegroundColor DarkGray; $_ } | Out-String
-            $exitCode = $LASTEXITCODE
-            Write-Host "   ────────────────────────────────────────" -ForegroundColor DarkGray
+            $result = Invoke-CopilotWithTimeout -Prompt $prompt -TimeoutMinutes $SessionTimeoutMinutes
+            $exitCode = $result.ExitCode
+            $copilotOutput = $result.Output
+            $timedOut = $result.TimedOut
         }
 
         # Step 6: Log result + heartbeat
@@ -614,15 +752,17 @@ while ($true) {
             Write-Host "[$($roundEnd.ToString('yyyy-MM-ddTHH:mm:ss'))] [OK] Round $round complete ($([math]::Round($duration, 1))s) [$metricsLine]" -ForegroundColor Green
         } else {
             $consecutiveFailures++
-            Write-RalphLog -Round $round -Status "FAIL" -ExitCode $exitCode -DurationSeconds $duration -Metrics $metrics
+            $failStatus = if ($timedOut) { "TIMEOUT" } else { "FAIL" }
+            Write-RalphLog -Round $round -Status $failStatus -ExitCode $exitCode -DurationSeconds $duration -Metrics $metrics
             Update-Heartbeat -Status "idle" -Round $round -Extra @{
                 lastDuration = [math]::Round($duration, 1)
-                lastStatus   = "FAIL"
+                lastStatus   = $failStatus
             }
-            Write-Host "[$($roundEnd.ToString('yyyy-MM-ddTHH:mm:ss'))] [FAIL] Round $round failed, exit code $exitCode ($([math]::Round($duration, 1))s)" -ForegroundColor Red
+            $failMsg = if ($timedOut) { "timed out after ${SessionTimeoutMinutes}m" } else { "exit code $exitCode" }
+            Write-Host "[$($roundEnd.ToString('yyyy-MM-ddTHH:mm:ss'))] [$failStatus] Round $round failed, $failMsg ($([math]::Round($duration, 1))s)" -ForegroundColor Red
 
             if ($consecutiveFailures -ge $alertThreshold) {
-                Write-FailureAlert -Round $round -Failures $consecutiveFailures -ExitCode $exitCode
+                Write-FailureAlert -Round $round -Failures $consecutiveFailures -ExitCode $exitCode -ErrorMessage $failMsg
             }
 
             # Circuit breaker
@@ -667,6 +807,8 @@ while ($true) {
         }
     }
 
+    } # end health check else
+
     # Check MaxRounds
     if ($MaxRounds -gt 0 -and $round -ge $MaxRounds) {
         Write-Host ""
@@ -682,10 +824,16 @@ while ($true) {
         break
     }
 
+    # Calculate interval with exponential backoff on failures
+    $currentInterval = Get-BackoffInterval -Failures $consecutiveFailures -BaseMinutes $baseInterval -MaxMinutes $maxBackoffMinutes
+    if ($currentInterval -ne $baseInterval) {
+        Write-Host "   [backoff] $consecutiveFailures consecutive failures. Interval: $currentInterval minutes (base: $baseInterval)" -ForegroundColor Yellow
+    }
+
     # Sleep (responsive to Ctrl+C and .ralph-stop)
-    Write-Host "   Next round in $IntervalMinutes minutes..." -ForegroundColor Gray
+    Write-Host "   Next round in $currentInterval minutes..." -ForegroundColor Gray
     Write-Host ""
-    $sleepTotal = $IntervalMinutes * 60
+    $sleepTotal = $currentInterval * 60
     $slept = 0
     while ($slept -lt $sleepTotal) {
         $chunk = [Math]::Min(10, $sleepTotal - $slept)


### PR DESCRIPTION
## P1-08: Ralph-Watch Hardening

**Goal:** Ralph runs 24h without failure or human intervention.

### What Changed

#### tools/ralph-watch.ps1 (v4 → v5)
- **Session timeout** (30m default): Copilot sessions that hang are killed after the limit. Exit code 124 = timeout.
- **Exponential backoff**: On consecutive failures, interval doubles: 5m → 10m → 20m → 40m → 60m (capped). Resets on success.
- **Stale lock detection**: If ralph-watch lock is >2h old with a running PID, it kills the stale process and takes over.
- **Pre-round health checks**: Validates copilot CLI, git, and disk space before each round. Skips round on failure.
- **Improved log rotation**: Keeps 3 rotated files instead of 1 (prevents log loss).
- **Context cleanup**: Removes temp files >2h old between cycles.

#### .github/workflows/squad-notify-ralph-heartbeat.yml
- **Hourly checks** (was every 4 hours) for faster failure detection.
- **Staleness detection**: Alerts if heartbeat timestamp is >30m stale while running, or >60m stale while idle.
- **Failure escalation**: Warns at 3+ failures, critical at 5+.
- **Auto-creates P0 issue** on critical alerts (with duplicate prevention).
- **Color-coded Discord** notifications (red = critical, yellow = warning, blue = info).

### Failure Modes Addressed

| Failure Mode | Before | After |
|---|---|---|
| Copilot hangs forever | Blocked indefinitely | Killed at 30m, logged as TIMEOUT |
| Rapid retry on failures | Same 5m interval | Exponential backoff to 60m |
| Stale lock file | Manual cleanup | Auto-detected at 2h |
| Log loss on rotation | Single .1 file | 3 rotated files |
| Silent crash | Detected at 4h intervals | Hourly staleness detection |
| No alerting | Local file only | Discord + GitHub Issue (P0) |
| Health degradation | No check | Pre-round validation |

### Testing
\\\powershell
# Dry run to verify script loads without errors
.\tools\ralph-watch.ps1 -DryRun -MaxRounds 1

# Custom timeout for testing
.\tools\ralph-watch.ps1 -SessionTimeoutMinutes 5 -MaxRounds 2
\\\

### Budget Impact
Zero additional Azure cost. All monitoring runs via GitHub Actions (included free tier).

---
**Tank** (Cloud Engineer) — P1-08